### PR TITLE
Add jps cli command skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# vscode workspace file
+*.code-workspace
+
+# pycache
+__pycache__/

--- a/jps/jps
+++ b/jps/jps
@@ -1,0 +1,7 @@
+#! /usr/bin/env python3
+import sys
+
+from jupedsim.application import Application
+
+if __name__ == "__main__":
+    sys.exit(Application().run())

--- a/jps/jupedsim/application.py
+++ b/jps/jupedsim/application.py
@@ -1,0 +1,78 @@
+import argparse
+import logging
+import sys
+
+from jupedsim.util.loghelper import log_debug, log_error, log_info, log_warning
+
+
+class Application:
+    def __init__(self):
+        self.commands = {}
+        self.setup_logging()
+        self.setup_main_arg_parser()
+        self.setup_generate_pedestrians_command()
+        self.setup_simulate_command()
+
+    def setup_logging(self):
+        logging.basicConfig(format=logging.BASIC_FORMAT)
+
+    def upgrade_logging(self):
+        logger_name = "JuPedSim"
+        if self.args.v == 1:
+            logging.getLogger(logger_name).setLevel(logging.INFO)
+        elif self.args.v == 2:
+            logging.getLogger(logger_name).setLevel(logging.DEBUG)
+        elif self.args.v >= 3:
+            # Enables all log messages from 3rd party libraries
+            logging.getLogger().setLevel(logging.DEBUG)
+
+    def setup_main_arg_parser(self):
+        self.parser = argparse.ArgumentParser()
+        self.parser.add_argument(
+            "-v",
+            action="count",
+            default=0,
+            help="Set verbosity level, use -v for info messages, "
+            "-vv for debug and -vvv for everything",
+        )
+        self.subparsers = self.parser.add_subparsers(
+            title="command", dest="cmd", required=True
+        )
+
+    def setup_generate_pedestrians_command(self):
+        command = "generate-pedestrians"
+        parser = self.subparsers.add_parser(
+            command, help="Will randomly place pedestrians in spawn areas",
+        )
+        self.commands[command] = lambda x: print("Not yet implemented")
+
+    def setup_simulate_command(self):
+        command = "simulate"
+        parser = self.subparsers.add_parser(
+            command, help="Will run a simulation"
+        )
+        parser.add_argument(
+            "--iterations",
+            required=True,
+            type=int,
+            metavar="count",
+            help="How many iterations to simulate",
+        )
+        self.commands[command] = lambda x: print("Not yet implemented")
+
+    def parse_arguments(self):
+        self.args = self.parser.parse_args()
+
+    def run(self):
+        self.parse_arguments()
+        self.upgrade_logging()
+
+        # Example log messages
+        log_info("hi")
+        log_debug("hi")
+        log_warning("hi")
+        log_error("hi")
+        # Example of a "3rd-party" log messages, i.e. a log message not
+        # send to the 'JuPedSim' logger
+        logging.debug("hi")
+        return self.commands[self.args.cmd](self.args)

--- a/jps/jupedsim/util/loghelper.py
+++ b/jps/jupedsim/util/loghelper.py
@@ -1,0 +1,19 @@
+import logging
+
+logger = logging.getLogger("JuPedSim")
+
+
+def log_debug(msg, **kwargs):
+    logger.debug(msg, **kwargs)
+
+
+def log_info(msg, **kwargs):
+    logger.info(msg, **kwargs)
+
+
+def log_warning(msg, **kwargs):
+    logger.warning(msg, **kwargs)
+
+
+def log_error(msg, **kwargs):
+    logger.error(msg, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 79
+target-version = ['py38']
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+
+[tool.isort]
+line_length = 79
+multi_line_output = 3
+include_trailing_comma = true


### PR DESCRIPTION
The cli command 'jps' has been added with two example commands
'simulate' and 'generate-pedestrians'.

Further the command supports to be called with '-v', '-vv' or '-vvv' for
different levels of verbosity.

'-v' enables informational messages
'-vv' additionally enables debug messages
'-vvv' additionaly enables all log messages from 3rd party libraries

Some example log message have been added for illustrative purposes