### PR TITLE
Add basic cpp setup

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.14)
+project(simulator CXX)
+
+################################################################################
+# Project setup
+################################################################################
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+include(helper_functions)
+check_prefix_path()
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+endif()
+
+################################################################################
+# Dependencies
+################################################################################
+find_package(GTest 1.10 CONFIG REQUIRED)
+include(GoogleTest)
+find_package(pybind11 2.5 CONFIG REQUIRED)
+find_package(Python 3.8 REQUIRED)
+
+################################################################################
+# Build sources
+################################################################################
+enable_testing()
+add_subdirectory(libcore)
+add_subdirectory(pycore)

--- a/cpp/cmake/helper_functions.cmake
+++ b/cpp/cmake/helper_functions.cmake
@@ -1,0 +1,17 @@
+function(print_var variable)
+    message(STATUS "${variable}=${${variable}}")
+endfunction()
+
+# There is a long outstanding issue with CMake where CMake does not support
+# relative paths in CMAKE_PREFIX_PATH but does not report anything. Many hours
+# have been wasted over this behavior. We are checking to save your this to
+# save everyone some headache. :)
+function(check_prefix_path)
+    if(CMAKE_PREFIX_PATH)
+        foreach(path ${CMAKE_PREFIX_PATH})
+            if(NOT IS_ABSOLUTE ${path})
+                message(FATAL_ERROR "CMake does not support relative paths for CMAKE_PREFIX_PATH! [${path}]")
+            endif()
+        endforeach()
+    endif()
+endfunction()

--- a/cpp/libcore/CMakeLists.txt
+++ b/cpp/libcore/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(source)
+add_subdirectory(test)

--- a/cpp/libcore/source/CMakeLists.txt
+++ b/cpp/libcore/source/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(core
+    simulation.cpp
+    simulation.hpp
+)
+
+target_include_directories(core
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/cpp/libcore/source/simulation.cpp
+++ b/cpp/libcore/source/simulation.cpp
@@ -1,0 +1,1 @@
+#include "simulation.hpp"

--- a/cpp/libcore/source/simulation.hpp
+++ b/cpp/libcore/source/simulation.hpp
@@ -1,0 +1,8 @@
+namespace jps
+{
+    class Simulation
+    {
+    public:
+        int getValue() { return 1; }
+    };
+} // namespace jps

--- a/cpp/libcore/test/CMakeLists.txt
+++ b/cpp/libcore/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(test-core
+    test_simulation.cpp
+)
+
+target_link_libraries(test-core
+    PRIVATE
+        core
+        GTest::gtest_main
+        GTest::gtest
+        GTest::gmock
+)
+
+gtest_discover_tests(test-core)

--- a/cpp/libcore/test/test_simulation.cpp
+++ b/cpp/libcore/test/test_simulation.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include <simulation.hpp>
+
+TEST(Example, SimulationReturns1)
+{
+    ASSERT_EQ(jps::Simulation().getValue(), 1);
+}

--- a/cpp/pycore/CMakeLists.txt
+++ b/cpp/pycore/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(source)
+add_subdirectory(test)

--- a/cpp/pycore/source/CMakeLists.txt
+++ b/cpp/pycore/source/CMakeLists.txt
@@ -1,0 +1,8 @@
+pybind11_add_module(jpscore
+    simulator_binding.cpp
+)
+
+target_link_libraries(jpscore
+    PRIVATE
+        core
+)

--- a/cpp/pycore/source/simulator_binding.cpp
+++ b/cpp/pycore/source/simulator_binding.cpp
@@ -1,0 +1,11 @@
+#include <pybind11/pybind11.h>
+#include <simulation.hpp>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(jpscore, m)
+{
+    py::class_<jps::Simulation>(m, "Simulation")
+        .def(py::init<>())
+        .def("get", &jps::Simulation::getValue);
+}

--- a/cpp/pycore/test/CMakeLists.txt
+++ b/cpp/pycore/test/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(python_tests
+    import_test.py
+    example_test.py
+)
+
+foreach(test ${python_tests})
+    add_test(
+        NAME ${test}
+        COMMAND ${Python_EXECUTABLE} -B -m pytest -p no:cacheprovider
+            ${CMAKE_CURRENT_SOURCE_DIR}/${test}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    set_tests_properties(${test} PROPERTIES
+        ENVIRONMENT PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    )
+endforeach()

--- a/cpp/pycore/test/example_test.py
+++ b/cpp/pycore/test/example_test.py
@@ -1,0 +1,6 @@
+import jpscore
+import pytest
+
+
+def test_example():
+    assert jpscore.Simulation().get() == 1

--- a/cpp/pycore/test/import_test.py
+++ b/cpp/pycore/test/import_test.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+def test_import():
+    """
+    Most basic test that just checks that jpscore can be
+    imported in python
+    """
+    try:
+        import jpscore
+    except:
+        pytest.fail("Could not import jpscore!")

--- a/cpp/scripts/README.md
+++ b/cpp/scripts/README.md
@@ -1,0 +1,19 @@
+# setup-dependencies.sh
+
+Use this script to download and install all native dependencies for C++ develeopment dependencies
+into an install tree.
+
+Usage is:
+
+```bash
+./setup-dependencies.sh <path-to-install-to>
+```
+
+Alternatively the install path can be omitted, in this case the installation will be done into
+`/usr/local`
+
+Currently the following dependencies are installed:
+
+* Googletest 1.10.0
+
+* Pybind11 2.5.0

--- a/cpp/scripts/setup-dependencies.sh
+++ b/cpp/scripts/setup-dependencies.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+set -ex
+
+pybind11_version=2.5.0
+googletest_version=1.10.0
+
+install_path=/usr/local
+if [ ${1} ]; then
+    install_path=${1}
+fi
+
+function setup_pybind11 {
+    root=$(pwd)
+    temp_folder=$(mktemp -d)
+    cd ${temp_folder}
+
+    wget https://github.com/pybind/pybind11/archive/v${pybind11_version}.tar.gz
+    tar xf v${pybind11_version}.tar.gz
+    cd pybind11-${pybind11_version}
+    mkdir build
+    cd build
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=${install_path} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DPYBIND11_TEST=Off
+    cmake --build . -j $(nproc)
+    cmake --install .
+    cd ${root}
+    rm -rf ${temp_folder}
+}
+
+function setup_googletest {
+    root=$(pwd)
+    temp_folder=$(mktemp -d)
+    cd ${temp_folder}
+
+    wget https://github.com/google/googletest/archive/release-${googletest_version}.tar.gz
+    tar xf release-${googletest_version}.tar.gz
+    cd googletest-release-${googletest_version}
+    mkdir build
+    cd build
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX=${install_path} \
+        -DCMAKE_BUILD_TYPE=Release
+    cmake --build . -j $(nproc)
+    cmake --install .
+    cd ${root}
+    rm -rf ${temp_folder}
+}
+
+setup_pybind11
+setup_googletest


### PR DESCRIPTION
Dependecies setup via setup-dependencies.sh
Initially contains:
	googletest 1.10.0
	pybind11 2.5.0

Usage: ./setup-dependencies.sh <location>

Example library added with unit test, python binding and python test
that actually calls imports and executes the example python binding.

All tests are available via ctest.