### PR TITLE
Add clang-tidy file

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -1,0 +1,15 @@
+---
+Checks: >-
+  -*,
+  bugprone-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  performance-*,
+  portability-*,
+  readability-*
+WarningsAsErrors:    '*'
+HeaderFilterRegex:   '.*'
+FormatStyle:         file

--- a/cpp/libcore/source/simulation.hpp
+++ b/cpp/libcore/source/simulation.hpp
@@ -3,6 +3,6 @@ namespace jps
     class Simulation
     {
     public:
-        int getValue() { return 1; }
+        static int getValue() { return 1; }
     };
 } // namespace jps

--- a/cpp/libcore/test/.clang-tidy
+++ b/cpp/libcore/test/.clang-tidy
@@ -1,0 +1,18 @@
+---
+Checks: >-
+  -*,
+  bugprone-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  misc-*,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  performance-*,
+  portability-*,
+  readability-*
+WarningsAsErrors:    '*'
+HeaderFilterRegex:   '.*'
+FormatStyle:         file


### PR DESCRIPTION
Used the clang-tidy config of jpscore as base, removed some redundant checks.

Is anything important missing?