### PR TITLE
Adds Configuration subfolder for Windows tests

### DIFF
--- a/cpp/pycore/test/CMakeLists.txt
+++ b/cpp/pycore/test/CMakeLists.txt
@@ -12,6 +12,6 @@ foreach(test ${python_tests})
     )
 
     set_tests_properties(${test} PROPERTIES
-        ENVIRONMENT PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}$<$<BOOL:${WIN32}>:/$<CONFIG>>
+        ENVIRONMENT PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<$<BOOL:${WIN32}>:$<CONFIG>>
     )
 endforeach()

--- a/cpp/pycore/test/CMakeLists.txt
+++ b/cpp/pycore/test/CMakeLists.txt
@@ -12,6 +12,6 @@ foreach(test ${python_tests})
     )
 
     set_tests_properties(${test} PROPERTIES
-        ENVIRONMENT PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+        ENVIRONMENT PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}$<$<BOOL:${WIN32}>:/$<CONFIG>>
     )
 endforeach()


### PR DESCRIPTION
Windows creates subfolders for different build configurations. For python to find the correct python package the corresponding folder must be added to the pythonpath environment variable.