### PR TITLE
Add libfmt

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -25,6 +25,7 @@ include(GoogleTest)
 set(PYBIND11_CPP_STANDARD -std=c++17)
 find_package(pybind11 2.5 CONFIG REQUIRED)
 find_package(Python 3.8 REQUIRED)
+find_package(fmt 7.1 CONFIG REQUIRED)
 
 ################################################################################
 # Build sources

--- a/cpp/libcore/source/CMakeLists.txt
+++ b/cpp/libcore/source/CMakeLists.txt
@@ -6,3 +6,7 @@ add_library(core
 target_include_directories(core
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+target_link_libraries(core
+    PUBLIC fmt::fmt
+)

--- a/cpp/libcore/test/CMakeLists.txt
+++ b/cpp/libcore/test/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_executable(test-core
     test_simulation.cpp
+    test_dependency_availability.cpp
 )
 
 target_link_libraries(test-core
     PRIVATE
         core
+        fmt::fmt
         GTest::gtest_main
         GTest::gtest
         GTest::gmock

--- a/cpp/libcore/test/test_dependency_availability.cpp
+++ b/cpp/libcore/test/test_dependency_availability.cpp
@@ -1,0 +1,10 @@
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <string_view>
+
+TEST(Fmt, IsAvailable)
+{
+    constexpr std::string_view expected = "a <-> b";
+    const auto formatted_string         = fmt::format("{} <-> {}", 'a', 'b');
+    ASSERT_EQ(formatted_string, expected);
+}

--- a/cpp/scripts/README.md
+++ b/cpp/scripts/README.md
@@ -16,6 +16,6 @@ Currently the following dependencies are installed:
 
 * Googletest 1.10.0 [https://github.com/google/googletest]
 
-* Pybind11 2.5.0 [https://github.com/pybind/pybind11]
+* Pybind11 2.6.1 [https://github.com/pybind/pybind11]
 
 * Fmt 7.1.2 [https://github.com/fmtlib/fmt]

--- a/cpp/scripts/README.md
+++ b/cpp/scripts/README.md
@@ -14,6 +14,8 @@ Alternatively the install path can be omitted, in this case the installation wil
 
 Currently the following dependencies are installed:
 
-* Googletest 1.10.0
+* Googletest 1.10.0 [https://github.com/google/googletest]
 
-* Pybind11 2.5.0
+* Pybind11 2.5.0 [https://github.com/pybind/pybind11]
+
+* Fmt 7.1.2 [https://github.com/fmtlib/fmt]

--- a/cpp/scripts/setup-dependencies.sh
+++ b/cpp/scripts/setup-dependencies.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -ex
 
-pybind11_version=2.5.0
+pybind11_version=2.6.1
 googletest_version=1.10.0
 fmt_version=7.1.2
 

--- a/cpp/scripts/setup-dependencies.sh
+++ b/cpp/scripts/setup-dependencies.sh
@@ -3,6 +3,7 @@ set -ex
 
 pybind11_version=2.5.0
 googletest_version=1.10.0
+fmt_version=7.1.2
 
 install_path=/usr/local
 if [ ${1} ]; then
@@ -48,5 +49,27 @@ function setup_googletest {
     rm -rf ${temp_folder}
 }
 
+function setup_fmt {
+    root=$(pwd)
+    temp_folder=$(mktemp -d)
+    cd ${temp_folder}
+
+    wget https://github.com/fmtlib/fmt/archive/${fmt_version}.tar.gz
+    tar xf ${fmt_version}.tar.gz
+    cd fmt-${fmt_version}
+    mkdir build
+    cd build
+    cmake .. \
+        -DFMT_DOC=OFF \
+        -DFMT_TEST=OFF \
+        -DCMAKE_INSTALL_PREFIX=${install_path} \
+        -DCMAKE_BUILD_TYPE=Release
+    cmake --build . -j $(nproc)
+    cmake --install .
+    cd ${root}
+    rm -rf ${temp_folder}
+}
+
 setup_pybind11
 setup_googletest
+setup_fmt


### PR DESCRIPTION
Fmt version 7.1.2 added. This includes a unit test to show correct
dependency handling in cmake.

Fixes: #15