### PR TITLE
Event file generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,18 @@ tramp
 .clangd/
 .cache/
 .ccls/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+pytestdebug.log

--- a/jps/jupedsim/application.py
+++ b/jps/jupedsim/application.py
@@ -69,6 +69,14 @@ class Application:
             help="Will randomly place pedestrian(s) in given areas",
         )
         parser.add_argument(
+            "-time",
+            required=False,
+            type=float,
+            metavar="time",
+            default=0,
+            help="Time the pedestrian(s) should be generated",
+        )
+        parser.add_argument(
             "-x",
             required=True,
             type=float,
@@ -94,18 +102,10 @@ class Application:
             help="ID of the floor the pedestrian(s) should be generated",
         )
         parser.add_argument(
-            "-time",
-            required=False,
-            type=float,
-            metavar="time",
-            default=0,
-            help="Time the pedestrian(s) should be generated",
-        )
-        parser.add_argument(
             "-overwrite",
             required=False,
             type=bool,
-            metavar="floor ID",
+            metavar="overwrite",
             help="Overwriting all existing spawn_pedestrian events in events file",
             default=False,
         )

--- a/jps/jupedsim/application.py
+++ b/jps/jupedsim/application.py
@@ -3,6 +3,8 @@ import logging
 import sys
 
 import jpscore
+
+from jupedsim.util.generator import process_generator
 from jupedsim.util.loghelper import log_debug, log_error, log_info, log_warning
 
 
@@ -64,9 +66,67 @@ class Application:
         command = "generate-pedestrians"
         parser = self.subparsers.add_parser(
             command,
-            help="Will randomly place pedestrians in spawn areas",
+            help="Will randomly place pedestrian(s) in given areas",
         )
-        self.commands[command] = lambda x: print("Not yet implemented")
+        parser.add_argument(
+            "-x",
+            required=True,
+            type=float,
+            metavar="x-pos",
+            nargs="+",
+            help="x-coordinate(s) the pedestrian(s) should be generated",
+        )
+        parser.add_argument(
+            "-y",
+            required=True,
+            type=float,
+            metavar="y-pos",
+            nargs="+",
+            help="y-coordinate(s) the pedestrian(s) should be generated",
+        )
+
+        parser.add_argument(
+            "-floor",
+            required=False,
+            type=int,
+            metavar="floor ID",
+            default=0,
+            help="ID of the floor the pedestrian(s) should be generated",
+        )
+        parser.add_argument(
+            "-time",
+            required=False,
+            type=float,
+            metavar="time",
+            default=0,
+            help="Time the pedestrian(s) should be generated",
+        )
+        parser.add_argument(
+            "-overwrite",
+            required=False,
+            type=bool,
+            metavar="floor ID",
+            help="Overwriting all existing spawn_pedestrian events in events file",
+            default=False,
+        )
+        parser.add_argument(
+            "-n",
+            required=False,
+            type=int,
+            metavar="number pedestrians",
+            default=1,
+            help="Number of pedestrians generated",
+        )
+
+        parser.add_argument(
+            "-o",
+            required=True,
+            type=str,
+            metavar="output file",
+            help="Output file",
+        )
+
+        self.commands[command] = lambda x: process_generator(self.args)
 
     def setup_simulate_command(self):
         command = "simulate"

--- a/jps/jupedsim/application.py
+++ b/jps/jupedsim/application.py
@@ -87,7 +87,7 @@ class Application:
             required=True,
             type=float,
             metavar="y-pos",
-            help="y-coordinate the pedestrian(s) should be generated [m]",
+            help="y-coordinate the pedestrian should be generated [m]",
         )
         parser.add_argument(
             "-level",

--- a/jps/jupedsim/application.py
+++ b/jps/jupedsim/application.py
@@ -3,7 +3,7 @@ import logging
 import sys
 
 import jpscore
-from jupedsim.util.generator import process_generator
+from jupedsim.util.generator import generate_spawn_events
 from jupedsim.util.loghelper import log_debug, log_error, log_info, log_warning
 
 
@@ -65,7 +65,7 @@ class Application:
         command = "generate-pedestrians"
         parser = self.subparsers.add_parser(
             command,
-            help="Will randomly place pedestrian(s) in given areas",
+            help="Places an agent at a given position.",
         )
         parser.add_argument(
             "-time",
@@ -73,32 +73,29 @@ class Application:
             type=float,
             metavar="time",
             default=0,
-            help="Time the pedestrian(s) should be generated",
+            help="Time the pedestrian should be generated [s]",
         )
         parser.add_argument(
             "-x",
             required=True,
             type=float,
             metavar="x-pos",
-            nargs="+",
-            help="x-coordinate(s) the pedestrian(s) should be generated",
+            help="x-coordinate the pedestrian should be generated [m]",
         )
         parser.add_argument(
             "-y",
             required=True,
             type=float,
             metavar="y-pos",
-            nargs="+",
-            help="y-coordinate(s) the pedestrian(s) should be generated",
+            help="y-coordinate the pedestrian(s) should be generated [m]",
         )
-
         parser.add_argument(
-            "-floor",
+            "-level",
             required=False,
             type=int,
-            metavar="floor ID",
+            metavar="level ID",
             default=0,
-            help="ID of the floor the pedestrian(s) should be generated",
+            help="ID of the level the pedestrian is generated according to the defined geometry",
         )
         parser.add_argument(
             "-overwrite",
@@ -109,15 +106,6 @@ class Application:
             default=False,
         )
         parser.add_argument(
-            "-n",
-            required=False,
-            type=int,
-            metavar="number pedestrians",
-            default=1,
-            help="Number of pedestrians generated",
-        )
-
-        parser.add_argument(
             "-o",
             required=True,
             type=str,
@@ -125,7 +113,7 @@ class Application:
             help="Output file",
         )
 
-        self.commands[command] = lambda x: process_generator(self.args)
+        self.commands[command] = generate_spawn_events
 
     def setup_simulate_command(self):
         command = "simulate"

--- a/jps/jupedsim/application.py
+++ b/jps/jupedsim/application.py
@@ -3,7 +3,6 @@ import logging
 import sys
 
 import jpscore
-
 from jupedsim.util.generator import process_generator
 from jupedsim.util.loghelper import log_debug, log_error, log_info, log_warning
 

--- a/jps/jupedsim/tests/test_dummy.py
+++ b/jps/jupedsim/tests/test_dummy.py
@@ -1,8 +1,0 @@
-"""
-pytest will emit error code 5 if there was no test run.
-For the CI we use this dummy test to check if the test infrastructure is working.
-"""
-
-
-def test_dummy_CI():
-    pass

--- a/jps/jupedsim/tests/test_event.py
+++ b/jps/jupedsim/tests/test_event.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass
+
+import pytest
+from jupedsim.util.event import Event, EventType, SpawnPedestrianEvent
+
+
+@dataclass
+class DummyEvent(EventType):
+    name: str
+
+    def __init__(self, name: str):
+        self.type = "dummy"
+        self.name = name
+
+
+class TestEventType:
+    @pytest.mark.parametrize(
+        "event, json_str",
+        [
+            (
+                SpawnPedestrianEvent([0, 0], 0),
+                SpawnPedestrianEvent([0, 0], 0).get_json(),
+            ),
+            (
+                SpawnPedestrianEvent([1.12, 56.5], 17),
+                SpawnPedestrianEvent([1.12, 56.5], 17).get_json(),
+            ),
+            (
+                SpawnPedestrianEvent([5.21, 0], 0),
+                SpawnPedestrianEvent([5.21, 0], 0).get_json(),
+            ),
+            (
+                SpawnPedestrianEvent([0, 1.5], 42),
+                SpawnPedestrianEvent([0, 1.5], 42).get_json(),
+            ),
+            (
+                SpawnPedestrianEvent([0, 1.5], 42),
+                '{"type": "spawn_pedestrian", "position": [0, 1.5], "floor": 42}',
+            ),
+        ],
+    )
+    def test_from_json_correct(self, event, json_str):
+        event_read = EventType.from_json(json_str)
+        assert event == event_read
+
+    @pytest.mark.parametrize(
+        "json_str",
+        [
+            '{"type": "foo", "position": [0, 0], "floor": 0}',
+            DummyEvent("test").get_json(),
+        ],
+    )
+    def test_from_json_incorrect(self, json_str):
+        with pytest.raises((ValueError, NotImplementedError)):
+            EventType.from_json(json_str)
+
+
+class TestSpawnPedestrianEvent:
+    @pytest.mark.parametrize(
+        "event, json_str",
+        [
+            (
+                SpawnPedestrianEvent([0, 0], 0),
+                SpawnPedestrianEvent([0, 0], 0).get_json(),
+            ),
+            (
+                SpawnPedestrianEvent([0, 0], 1),
+                SpawnPedestrianEvent([0, 0], 1).get_json(),
+            ),
+            (
+                SpawnPedestrianEvent([0, 0], 1),
+                '{"type": "spawn_pedestrian", "position": [0, 0], "floor": 1}',
+            ),
+            (
+                SpawnPedestrianEvent([0, 0], 1),
+                '{"type": "spawn_pedestrian", "position": [0, 0], "floor": 1, "test": [0, 0]}',
+            ),
+        ],
+    )
+    def test_from_json_correct(self, event, json_str):
+        event_read = SpawnPedestrianEvent.from_json(json_str)
+        assert event == event_read
+
+    @pytest.mark.parametrize(
+        "json_str",
+        [
+            (SpawnPedestrianEvent(["test", 0], 0).get_json()),
+            (SpawnPedestrianEvent([0, 0], "floor").get_json()),
+            (SpawnPedestrianEvent([0, 0, 0], 0).get_json()),
+            (SpawnPedestrianEvent(0, 0).get_json()),
+            '{"type": "spawn_pedestrian", "position": 0, "floor": 0}',
+            '{"type": "spawn_pedestrian", "floor": 0}',
+            '{"type": "spawn_pedestrian", "position": 0}',
+            '{"type": "spawn_pedestrian", "position": 0, "floor": 0, "test": [0, 0]}',
+            '{"type": }',
+        ],
+    )
+    def test_from_json_incorrect(self, json_str):
+        with pytest.raises(ValueError):
+            SpawnPedestrianEvent.from_json(json_str)
+
+
+class TestEvent:
+    @pytest.mark.parametrize(
+        "event, json_str",
+        [
+            (
+                Event(0, SpawnPedestrianEvent([0, 0], 0)),
+                Event(0, SpawnPedestrianEvent([0, 0], 0)).get_json(),
+            ),
+            (
+                Event(0.5, SpawnPedestrianEvent([0.25, 0], 6)),
+                Event(0.5, SpawnPedestrianEvent([0.25, 0], 6)).get_json(),
+            ),
+            (
+                Event(0, SpawnPedestrianEvent([0, 0], 0)),
+                '{"time": 0, "event": '
+                '{"type": "spawn_pedestrian", "position": [0, 0], "floor": 0}, "test":"still_correct"}',
+            ),
+        ],
+    )
+    def test_from_json_correct(self, event, json_str):
+        event_read = Event.from_json(json_str)
+        assert event == event_read
+
+    @pytest.mark.parametrize(
+        "json_str",
+        [
+            Event(0.5, DummyEvent("test")).get_json(),
+            '{"time": -1, "event": {"type": "spawn_pedestrian", "position": [0, 0], "floor": 0}}',
+            '{"time": "test", "event": {"type": "spawn_pedestrian", "position": [0, 0], "floor": 0}}',
+            '{"time": 0, "no_event": {"type": "spawn_pedestrian", "position": [0, 0], "floor": 0}}',
+            '{"time": 0,',
+        ],
+    )
+    def test_from_json_incorrect(self, json_str):
+        with pytest.raises((ValueError, NotImplementedError)):
+            Event.from_json(json_str)

--- a/jps/jupedsim/tests/util/conftest.py
+++ b/jps/jupedsim/tests/util/conftest.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import pytest
 from jupedsim.util.event import EventType
 
 
@@ -10,8 +9,14 @@ class DummyEvent(EventType):
 
 
 def equal_ignore_order(a, b):
-    """ Use only when elements are neither hashable nor sortable! """
+    """
+    Use only when elements are neither hashable nor sortable!
+    See: https://stackoverflow.com/a/7829388 for more details
+
+    Tries to remove every element of a from b. Afterwards checks if b is empty.
+    """
     unmatched = list(b)
+
     for element in a:
         try:
             unmatched.remove(element)

--- a/jps/jupedsim/tests/util/conftest.py
+++ b/jps/jupedsim/tests/util/conftest.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+import pytest
+from jupedsim.util.event import EventType
+
+
+@dataclass(frozen=True, eq=True)
+class DummyEvent(EventType):
+    name: str = "dummy"
+
+
+def equal_ignore_order(a, b):
+    """ Use only when elements are neither hashable nor sortable! """
+    unmatched = list(b)
+    for element in a:
+        try:
+            unmatched.remove(element)
+        except ValueError:
+            return False
+    return not unmatched

--- a/jps/jupedsim/tests/util/test_event.py
+++ b/jps/jupedsim/tests/util/test_event.py
@@ -1,16 +1,8 @@
 from dataclasses import dataclass
 
 import pytest
+from jupedsim.tests.util.conftest import DummyEvent
 from jupedsim.util.event import Event, EventType, SpawnPedestrianEvent
-
-
-@dataclass
-class DummyEvent(EventType):
-    name: str
-
-    def __init__(self, name: str):
-        self.type = "dummy"
-        self.name = name
 
 
 class TestEventType:

--- a/jps/jupedsim/tests/util/test_event.py
+++ b/jps/jupedsim/tests/util/test_event.py
@@ -14,8 +14,8 @@ class TestEventType:
                 SpawnPedestrianEvent([0, 0], 0).get_json(),
             ),
             (
-                SpawnPedestrianEvent([1.12, 56.5], 17),
-                SpawnPedestrianEvent([1.12, 56.5], 17).get_json(),
+                SpawnPedestrianEvent([1.12, -56.5], 17),
+                SpawnPedestrianEvent([1.12, -56.5], 17).get_json(),
             ),
             (
                 SpawnPedestrianEvent([5.21, 0], 0),
@@ -26,8 +26,20 @@ class TestEventType:
                 SpawnPedestrianEvent([0, 1.5], 42).get_json(),
             ),
             (
+                SpawnPedestrianEvent([0, 1.5], -2),
+                SpawnPedestrianEvent([0, 1.5], -2).get_json(),
+            ),
+            (
+                SpawnPedestrianEvent([-12.54, 23.1], -2),
+                SpawnPedestrianEvent([-12.54, 23.1], -2).get_json(),
+            ),
+            (
+                SpawnPedestrianEvent([-12.54, -3.81], -2),
+                SpawnPedestrianEvent([-12.54, -3.81], -2).get_json(),
+            ),
+            (
                 SpawnPedestrianEvent([0, 1.5], 42),
-                '{"type": "spawn_pedestrian", "position": [0, 1.5], "floor": 42}',
+                '{"type": "spawn_pedestrian", "position": [0, 1.5], "level": 42}',
             ),
         ],
     )
@@ -38,7 +50,7 @@ class TestEventType:
     @pytest.mark.parametrize(
         "json_str",
         [
-            '{"type": "foo", "position": [0, 0], "floor": 0}',
+            '{"type": "foo", "position": [0, 0], "level": 0}',
             DummyEvent("test").get_json(),
         ],
     )
@@ -61,11 +73,11 @@ class TestSpawnPedestrianEvent:
             ),
             (
                 SpawnPedestrianEvent([0, 0], 1),
-                '{"type": "spawn_pedestrian", "position": [0, 0], "floor": 1}',
+                '{"type": "spawn_pedestrian", "position": [0, 0], "level": 1}',
             ),
             (
                 SpawnPedestrianEvent([0, 0], 1),
-                '{"type": "spawn_pedestrian", "position": [0, 0], "floor": 1, "test": [0, 0]}',
+                '{"type": "spawn_pedestrian", "position": [0, 0], "level": 1, "test": [0, 0]}',
             ),
         ],
     )
@@ -77,13 +89,13 @@ class TestSpawnPedestrianEvent:
         "json_str",
         [
             (SpawnPedestrianEvent(["test", 0], 0).get_json()),
-            (SpawnPedestrianEvent([0, 0], "floor").get_json()),
+            (SpawnPedestrianEvent([0, 0], "level").get_json()),
             (SpawnPedestrianEvent([0, 0, 0], 0).get_json()),
             (SpawnPedestrianEvent(0, 0).get_json()),
-            '{"type": "spawn_pedestrian", "position": 0, "floor": 0}',
-            '{"type": "spawn_pedestrian", "floor": 0}',
+            '{"type": "spawn_pedestrian", "position": 0, "level": 0}',
+            '{"type": "spawn_pedestrian", "level": 0}',
             '{"type": "spawn_pedestrian", "position": 0}',
-            '{"type": "spawn_pedestrian", "position": 0, "floor": 0, "test": [0, 0]}',
+            '{"type": "spawn_pedestrian", "position": 0, "level": 0, "test": [0, 0]}',
             '{"type": }',
         ],
     )
@@ -105,9 +117,13 @@ class TestEvent:
                 Event(0.5, SpawnPedestrianEvent([0.25, 0], 6)).get_json(),
             ),
             (
+                Event(0.5, SpawnPedestrianEvent([0.25, 0], 6)),
+                Event(0.5, SpawnPedestrianEvent([0.25, 0], 6)).get_json(),
+            ),
+            (
                 Event(0, SpawnPedestrianEvent([0, 0], 0)),
                 '{"time": 0, "event": '
-                '{"type": "spawn_pedestrian", "position": [0, 0], "floor": 0}, "test":"still_correct"}',
+                '{"type": "spawn_pedestrian", "position": [0, 0], "level": 0}, "test":"still_correct"}',
             ),
         ],
     )
@@ -119,9 +135,9 @@ class TestEvent:
         "json_str",
         [
             Event(0.5, DummyEvent("test")).get_json(),
-            '{"time": -1, "event": {"type": "spawn_pedestrian", "position": [0, 0], "floor": 0}}',
-            '{"time": "test", "event": {"type": "spawn_pedestrian", "position": [0, 0], "floor": 0}}',
-            '{"time": 0, "no_event": {"type": "spawn_pedestrian", "position": [0, 0], "floor": 0}}',
+            '{"time": -1, "event": {"type": "spawn_pedestrian", "position": [0, 0], "level": 0}}',
+            '{"time": "test", "event": {"type": "spawn_pedestrian", "position": [0, 0], "level": 0}}',
+            '{"time": 0, "no_event": {"type": "spawn_pedestrian", "position": [0, 0], "level": 0}}',
             '{"time": 0,',
         ],
     )

--- a/jps/jupedsim/tests/util/test_generator.py
+++ b/jps/jupedsim/tests/util/test_generator.py
@@ -1,0 +1,306 @@
+import json
+from typing import List
+
+import pytest
+from jupedsim.tests.util.conftest import DummyEvent, equal_ignore_order
+from jupedsim.util.event import (
+    DataclassJSONEncoder,
+    Event,
+    SpawnPedestrianEvent,
+)
+from jupedsim.util.generator import (
+    generate_pedestrian_on_position,
+    merge_spawn_pedestrian_events,
+    read_events,
+)
+
+
+class TestGenerator:
+    @pytest.mark.parametrize(
+        "filename, events, exception",
+        [
+            ("", [], FileNotFoundError),
+            (
+                "read_events_incorrect.json",
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(1, DummyEvent("dummy")),
+                ],
+                NotImplementedError,
+            ),
+            (
+                "read_events_incorrect.json",
+                [Event(-1, SpawnPedestrianEvent([1, -5], 1))],
+                ValueError,
+            ),
+        ],
+    )
+    def test_read_events_incorrect(
+        self, tmpdir, filename, events: List[Event], exception
+    ):
+        foo = SpawnPedestrianEvent([0, 0], 1)
+        if not filename:
+            file = filename
+        else:
+            file = tmpdir / filename
+            file.write(json.dumps(events, indent=4, cls=DataclassJSONEncoder))
+
+        with pytest.raises(exception):
+            read_events(file)
+
+    @pytest.mark.parametrize(
+        "events",
+        (
+            [],
+            [
+                Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                Event(123, SpawnPedestrianEvent([21, -5], 1)),
+            ],
+        ),
+    )
+    def test_read_events_correct(self, tmpdir, events: List[Event]):
+        file = tmpdir / "read_events_correct.json"
+        file.write(json.dumps(events, indent=4, cls=DataclassJSONEncoder))
+        result = read_events(file)
+        assert events == result
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            Event(0, SpawnPedestrianEvent([0, 0], 1)),
+            Event(50, SpawnPedestrianEvent([6, -34], -1)),
+            Event(123, SpawnPedestrianEvent([-1221, 435], 2)),
+            Event(56123, SpawnPedestrianEvent([12, 85], 4)),
+        ],
+    )
+    def test_generate_pedestrian_position(self, event: Event):
+        generated_ped = generate_pedestrian_on_position(
+            event.time, event.event.position, event.event.floor
+        )
+        assert len(generated_ped) == 1
+        assert generated_ped[0] == event
+
+    @pytest.mark.parametrize(
+        "events, existing_events, expected",
+        [
+            (
+                [],
+                [],
+                [],
+            ),
+            (
+                [],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+                [],
+            ),
+            (
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+                [],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+            ),
+            (
+                [],
+                [
+                    Event(0, DummyEvent("dummy")),
+                ],
+                [
+                    Event(0, DummyEvent("dummy")),
+                ],
+            ),
+            (
+                [],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(4123, DummyEvent("dummy")),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                    Event(0, DummyEvent("dummy")),
+                ],
+                [
+                    Event(0, DummyEvent("dummy")),
+                    Event(4123, DummyEvent("dummy")),
+                ],
+            ),
+            (
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+                [
+                    Event(0, SpawnPedestrianEvent([56, 11], 1)),
+                    Event(23, SpawnPedestrianEvent([123, 7], -1)),
+                    Event(98, SpawnPedestrianEvent([-678, 12], 0)),
+                    Event(4123, DummyEvent("dummy")),
+                    Event(672, SpawnPedestrianEvent([-20, -5], 1)),
+                    Event(0, DummyEvent("dummy")),
+                ],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                    Event(4123, DummyEvent("dummy")),
+                    Event(0, DummyEvent("dummy")),
+                ],
+            ),
+        ],
+    )
+    def test_merge_spawn_pedestrian_events_overwrite(
+        self,
+        events: List[Event],
+        existing_events: List[Event],
+        expected: List[Event],
+    ):
+        merged_events = merge_spawn_pedestrian_events(
+            events, existing_events, True
+        )
+        assert equal_ignore_order(merged_events, expected)
+
+    @pytest.mark.parametrize(
+        "events, existing_events, expected",
+        [
+            (
+                [],
+                [],
+                [],
+            ),
+            (
+                [],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+            ),
+            (
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+                [],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+            ),
+            (
+                [],
+                [
+                    Event(0, DummyEvent("dummy")),
+                    Event(123, DummyEvent("dummy")),
+                ],
+                [
+                    Event(0, DummyEvent("dummy")),
+                    Event(123, DummyEvent("dummy")),
+                ],
+            ),
+            (
+                [],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                    Event(0, DummyEvent("dummy")),
+                    Event(123, DummyEvent("dummy")),
+                ],
+                [
+                    Event(0, DummyEvent("dummy")),
+                    Event(123, DummyEvent("dummy")),
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+            ),
+            (
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+                [
+                    Event(0, DummyEvent("dummy")),
+                    Event(123, DummyEvent("dummy")),
+                ],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                    Event(0, DummyEvent("dummy")),
+                    Event(123, DummyEvent("dummy")),
+                ],
+            ),
+            (
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                ],
+                [
+                    Event(0, DummyEvent("dummy")),
+                    Event(0, SpawnPedestrianEvent([23, -5], 4)),
+                    Event(43, SpawnPedestrianEvent([96, 5], -1)),
+                    Event(123, DummyEvent("dummy")),
+                    Event(512, SpawnPedestrianEvent([8, -45], 1)),
+                ],
+                [
+                    Event(0, SpawnPedestrianEvent([1, -5], 1)),
+                    Event(30, SpawnPedestrianEvent([11, 5], -1)),
+                    Event(432, SpawnPedestrianEvent([-12, -5], 0)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                    Event(123, SpawnPedestrianEvent([21, -5], 1)),
+                    Event(0, DummyEvent("dummy")),
+                    Event(0, SpawnPedestrianEvent([23, -5], 4)),
+                    Event(43, SpawnPedestrianEvent([96, 5], -1)),
+                    Event(123, DummyEvent("dummy")),
+                    Event(512, SpawnPedestrianEvent([8, -45], 1)),
+                ],
+            ),
+        ],
+    )
+    def test_merge_spawn_pedestrian_events_non_overwrite(
+        self,
+        events: List[Event],
+        existing_events: List[Event],
+        expected: List[Event],
+    ):
+        merged_events = merge_spawn_pedestrian_events(
+            events, existing_events, False
+        )
+        assert equal_ignore_order(merged_events, expected)

--- a/jps/jupedsim/util/event.py
+++ b/jps/jupedsim/util/event.py
@@ -40,15 +40,15 @@ class EventType:
 @dataclass(init=False, frozen=True, eq=True)
 class SpawnPedestrianEvent(EventType):
     """
-    EventType for spawning pedestrians at a given position on a specific floor
+    EventType for spawning pedestrians at a given position on a specific level
     """
 
     position: List[float]
-    floor: int
+    level: int
 
-    def __init__(self, position: List[float], floor: int):
+    def __init__(self, position: List[float], level: int):
         object.__setattr__(self, "position", position)
-        object.__setattr__(self, "floor", floor)
+        object.__setattr__(self, "level", level)
         object.__setattr__(self, "type", "spawn_pedestrian")
         return
 
@@ -67,13 +67,13 @@ class SpawnPedestrianEvent(EventType):
                 )
             )
 
-        floor = json_data.get("floor")
-        if not isinstance(floor, int):
+        level = json_data.get("level")
+        if not isinstance(level, int):
             raise ValueError(
-                '"floor" needs to be a integer value, but is {}.'.format(floor)
+                '"level" needs to be a integer value, but is {}.'.format(level)
             )
 
-        return cls(position, floor)
+        return cls(position, level)
 
 
 @dataclass(frozen=True, eq=True)

--- a/jps/jupedsim/util/event.py
+++ b/jps/jupedsim/util/event.py
@@ -12,7 +12,7 @@ class DataclassJSONEncoder(json.JSONEncoder):
         return super().default(o)
 
 
-@dataclass
+@dataclass(frozen=True, eq=True)
 class EventType:
     """
     Abstract base class defining the type of events.
@@ -37,7 +37,7 @@ class EventType:
         )
 
 
-@dataclass
+@dataclass(init=False, frozen=True, eq=True)
 class SpawnPedestrianEvent(EventType):
     """
     EventType for spawning pedestrians at a given position on a specific floor
@@ -47,9 +47,9 @@ class SpawnPedestrianEvent(EventType):
     floor: int
 
     def __init__(self, position: List[float], floor: int):
-        self.type = "spawn_pedestrian"
-        self.position = position
-        self.floor = floor
+        object.__setattr__(self, "position", position)
+        object.__setattr__(self, "floor", floor)
+        object.__setattr__(self, "type", "spawn_pedestrian")
         return
 
     @classmethod
@@ -76,7 +76,7 @@ class SpawnPedestrianEvent(EventType):
         return cls(position, floor)
 
 
-@dataclass
+@dataclass(frozen=True, eq=True)
 class Event:
     """
     Class for storing the information which EventType is triggered at a given time.
@@ -86,8 +86,8 @@ class Event:
     event: EventType
 
     def __init__(self, time: float, event: EventType):
-        self.time = time
-        self.event = event
+        object.__setattr__(self, "time", time)
+        object.__setattr__(self, "event", event)
         return
 
     def get_json(self) -> str:

--- a/jps/jupedsim/util/event.py
+++ b/jps/jupedsim/util/event.py
@@ -1,0 +1,92 @@
+import dataclasses
+import json
+from abc import abstractmethod
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, NamedTuple
+
+
+class DataclassJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        return super().default(o)
+
+
+@dataclass
+class EventType:
+    """
+    Abstract base class defining the type of events.
+    """
+
+    type: str
+
+    @abstractmethod
+    def get_json(self) -> str:
+        pass
+
+    @classmethod
+    def from_json(cls, data):
+        if data["type"] == "spawn_pedestrian":
+            spawn = SpawnPedestrianEvent.from_json(data)
+            return spawn
+
+        return None
+
+
+@dataclass
+class SpawnPedestrianEvent(EventType):
+    """
+    EventType for spawning pedestrians at a given position on a specific floor
+    """
+
+    position: Any
+    floor: int
+
+    def __init__(self, position, floor: int):
+        self.position = position
+        self.floor = floor
+        self.type = "spawn_pedestrian"
+        return
+
+    def get_json(self) -> str:
+        return json.dumps(self, default=lambda o: o.__dict__)
+
+    @classmethod
+    def from_json(cls, data):
+        position = data["position"]
+        floor = data["floor"]
+        return cls(position, floor)
+
+    def __eq__(self, other):
+        if type(self) is type(other):
+            return (
+                self.position == other.position and self.floor == other.floor
+            )
+        return False
+
+
+@dataclass
+class Event:
+    """
+    Class for storing the information which EventType is triggered at a given time.
+    """
+
+    time: float
+    event: EventType
+
+    def __init__(self, time: float, event: EventType):
+        self.time = time
+        self.event = event
+        return
+
+    def get_json(self) -> str:
+        return json.dumps(self, default=lambda o: o.__dict__)
+
+    @classmethod
+    def from_json(cls, data):
+        return cls(data["time"], EventType.from_json(data["event"]))
+
+    def __eq__(self, other):
+        if type(self) is type(other):
+            return self.time == other.time and self.event == other.event
+        return False

--- a/jps/jupedsim/util/generator.py
+++ b/jps/jupedsim/util/generator.py
@@ -9,24 +9,20 @@ from jupedsim.util.event import (
 from jupedsim.util.loghelper import log_debug, log_error, log_info, log_warning
 
 
-def process_generator(args) -> None:
+def generate_spawn_events(args) -> None:
     """
-    Processes the event file generator
+    Generates all spawn events defined in args. Args contains time and position of the pedestrian, and also the
+    output information (file, overwriting).
     :param args: Commandline arguments
     :return:
     """
-    events = []
-    if args.floor is not None:
-        log_error("need floor")
-    if len(args.x) == 1 and len(args.y) == 1 and args.floor is not None:
-        if args.n != 1:
-            log_warning("number of pedestrians != 1")
-        else:
-            events = generate_pedestrian_on_position(
-                args.time, [args.x[0], args.y[0]], args.floor
-            )
-
+    events = generate_pedestrian_on_position(
+        args.time, [args.x, args.y], args.level
+    )
     write_to_event_file(args.o, events, args.overwrite)
+    log_info(
+        "Generate pedestrian events have been written to: {}".format(args.o)
+    )
 
 
 def read_events(file) -> List[Event]:
@@ -45,16 +41,16 @@ def read_events(file) -> List[Event]:
 
 
 def generate_pedestrian_on_position(
-    time: float, position, floor: int
+    time: float, position, level: int
 ) -> List[Event]:
     """
-    Generates one pedestrian at time at position in floor.
+    Generates one pedestrian at time at position in level.
     :param time: Time the pedestrian is spawned
     :param position: Position the pedestrian is spawned
-    :param floor: Floor the pedestrian is spawned
+    :param level: Level the pedestrian is spawned
     :return: List of length one containing the spawn pedestrian event
     """
-    spawn_event = SpawnPedestrianEvent(position, floor)
+    spawn_event = SpawnPedestrianEvent(position, level)
     return [Event(time, spawn_event)]
 
 
@@ -98,7 +94,7 @@ def write_to_event_file(
     :param overwrite: Existing SpawnPedestrianEvents will be overwritten
     :return: success
     """
-    existing_events = read_events(file)
+    existing_events = read_events(file) if overwrite else []
     events = merge_spawn_pedestrian_events(events, existing_events, overwrite)
 
     with open(file, "w+") as json_file:

--- a/jps/jupedsim/util/generator.py
+++ b/jps/jupedsim/util/generator.py
@@ -39,7 +39,7 @@ def read_events(file) -> List[Event]:
     with open(file) as json_file:
         objs = json.load(json_file)
         for obj in objs:
-            test = Event.from_json(obj)
+            test = Event.from_json(json.dumps(obj))
             events.append(test)
     return events
 

--- a/jps/jupedsim/util/generator.py
+++ b/jps/jupedsim/util/generator.py
@@ -1,0 +1,87 @@
+import json
+from typing import List
+
+from jupedsim.util.event import (
+    DataclassJSONEncoder,
+    Event,
+    SpawnPedestrianEvent,
+)
+from jupedsim.util.loghelper import log_debug, log_error, log_info, log_warning
+
+
+def process_generator(args) -> None:
+    """
+    Processes the event file generator
+    :param args: Commandline arguments
+    :return:
+    """
+    events = []
+    if args.floor is not None:
+        log_error("need floor")
+    if len(args.x) == 1 and len(args.y) == 1 and args.floor is not None:
+        if args.n != 1:
+            log_warning("number of pedestrians != 1")
+        else:
+            events = generate_pedestrian_on_position(
+                args.time, [args.x[0], args.y[0]], args.floor
+            )
+
+    write_to_event_file(args.o, events, args.overwrite)
+
+
+def read_events(file) -> List[Event]:
+    """
+    Reads from a file and creates a list of Events
+    :param file: path to a json file containing events
+    :return: List of Events from json file
+    """
+    events = []
+    with open(file) as json_file:
+        objs = json.load(json_file)
+        for obj in objs:
+            test = Event.from_json(obj)
+            events.append(test)
+    return events
+
+
+def generate_pedestrian_on_position(
+    time: float, position, floor: int
+) -> List[Event]:
+    """
+    Generates one pedestrian at time at position in floor.
+    :param time: Time the pedestrian is spawned
+    :param position: Position the pedestrian is spawned
+    :param floor: Floor the pedestrian is spawned
+    :return: List of length one containing the spawn pedestrian event
+    """
+    spawn_event = SpawnPedestrianEvent(position, floor)
+    return [Event(time, spawn_event)]
+
+
+def write_to_event_file(
+    file: str, events: List[Event], overwrite: bool
+) -> bool:
+    """
+    Writes the list of events to the given file. If overwrite is set, all events which
+    are SpawnPedestrianEvents will be deleted.
+    :param file: Output file
+    :param events: List of SpawnPedestrianEvents
+    :param overwrite: Existing SpawnPedestrianEvents will be overwritten
+    :return: success
+    """
+    existing_events = read_events(file)
+
+    if overwrite:
+        other_events = [
+            event
+            for event in existing_events
+            if event.event.type == "spawn_pedestrians"
+        ]
+        events = other_events + events
+    else:
+        events = existing_events + events
+
+    with open(file, "w+") as json_file:
+        json_file.write(json.dumps(events, indent=4, cls=DataclassJSONEncoder))
+
+    return True


### PR DESCRIPTION
Simple event file generator to create one single pedestrian at a given time on a position on a specific floor:
```bash
jps generate-pedestrians -t 5.5 -x 1 -y 10 -o events.json
```
Following options are allowed:
```
usage: jps generate-pedestrians [-h] [-time time] -x x-pos [x-pos ...] -y y-pos [y-pos ...] [-floor floor ID] [-overwrite overwrite] [-n number pedestrians] -o output file

optional arguments:
  -h, --help            show this help message and exit
  -time time            Time the pedestrian(s) should be generated
  -x x-pos [x-pos ...]  x-coordinate(s) the pedestrian(s) should be generated
  -y y-pos [y-pos ...]  y-coordinate(s) the pedestrian(s) should be generated
  -floor floor ID       ID of the floor the pedestrian(s) should be generated
  -overwrite overwrite  Overwriting all existing spawn_pedestrian events in events file
  -n number pedestrians
                        Number of pedestrians generated
  -o output file        Output file
```

- [x] Single pedestrian at a specific position
- [ ] ~~Single pedestrian inside a area (bounding box from command line)~~ (Will be added later)
