### PR TITLE
Fixes missing nproc command on MacOS in deps script

### DIFF
--- a/cpp/scripts/setup-dependencies.sh
+++ b/cpp/scripts/setup-dependencies.sh
@@ -70,7 +70,7 @@ function setup_fmt {
         -DFMT_TEST=OFF \
         -DCMAKE_INSTALL_PREFIX=${install_path} \
         -DCMAKE_BUILD_TYPE=Release
-    cmake --build . -j $(nproc)
+    cmake --build . -j ${CPUS}
     cmake --install .
     cd ${root}
     rm -rf ${temp_folder}


### PR DESCRIPTION
Unfortunately i merged this "bug" yesterday. Just exchanged nproc command with the number of CPUs determined platform specific upfront. 