### PR TITLE
Fixes clang tidy naming config and names

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -29,9 +29,9 @@ CheckOptions:
     value: camelBack
   - key: readability-identifier-naming.MemberCase
     value: lower_case
-  - key: readability-identifier-naming.PublicMemberPrefix
-    value:
-  - key: readability-identifier-naming.MemberPrefix
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.ProtectedMemberPrefix
     value: m_
   - key: readability-identifier-naming.VariableCase
     value: lower_case

--- a/cpp/libcore/source/enum.hpp
+++ b/cpp/libcore/source/enum.hpp
@@ -1,7 +1,7 @@
 #include <type_traits>
 
 template <typename T>
-constexpr auto to_underlying(const T & t) noexcept
+constexpr auto toUnderlying(const T & p_t) noexcept
 {
-    return static_cast<std::underlying_type_t<T>>(t);
+    return static_cast<std::underlying_type_t<T>>(p_t);
 }

--- a/cpp/libcore/source/log.cpp
+++ b/cpp/libcore/source/log.cpp
@@ -13,7 +13,7 @@ namespace jps
 class Log
 {
 private:
-    std::array<Logging::LogCallback, 4> callbacks{};
+    std::array<Logging::LogCallback, 4> m_callbacks{};
 
 public:
     static Log & instance()
@@ -22,46 +22,46 @@ public:
         return log;
     }
 
-    void set_callback(Logging::Level level, Logging::LogCallback callback)
+    void setCallback(Logging::Level p_level, Logging::LogCallback p_callback)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        callbacks[to_underlying(level)] = std::move(callback);
+        m_callbacks[toUnderlying(p_level)] = std::move(p_callback);
     }
 
-    void msg(Logging::Level level, std::string_view msg)
+    void msg(Logging::Level p_level, std::string_view p_msg)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        if(auto & cb = callbacks[to_underlying(level)]; cb) {
-            cb(msg);
+        if(auto & cb = m_callbacks[toUnderlying(p_level)]; cb) {
+            cb(p_msg);
         }
     }
 };
 
 namespace Logging
 {
-void Debug(std::string_view msg)
+void debug(std::string_view p_msg)
 {
-    Log::instance().msg(Level::Debug, msg);
+    Log::instance().msg(Level::Debug, p_msg);
 }
 
-void Info(std::string_view msg)
+void info(std::string_view p_msg)
 {
-    Log::instance().msg(Level::Info, msg);
+    Log::instance().msg(Level::Info, p_msg);
 }
 
-void Warning(std::string_view msg)
+void warning(std::string_view p_msg)
 {
-    Log::instance().msg(Level::Warning, msg);
+    Log::instance().msg(Level::Warning, p_msg);
 }
 
-void Error(std::string_view msg)
+void error(std::string_view p_msg)
 {
-    Log::instance().msg(Level::Error, msg);
+    Log::instance().msg(Level::Error, p_msg);
 }
 
-void SetCallback(Level level, LogCallback callback)
+void setCallback(Level p_level, LogCallback p_callback)
 {
-    Log::instance().set_callback(level, std::move(callback));
+    Log::instance().setCallback(p_level, std::move(p_callback));
 }
 } // namespace Logging
 } // namespace jps

--- a/cpp/libcore/source/log.hpp
+++ b/cpp/libcore/source/log.hpp
@@ -14,23 +14,23 @@ using LogCallback = std::function<void(std::string_view)>;
 
 /// This function is not supposed to be called directly from library code, use LOG_DEBUG(...)
 /// instead.
-void Debug(std::string_view msg);
+void debug(std::string_view p_msg);
 /// This function is not supposed to be called directly from library code, use LOG_INFO(...)
 /// instead.
-void Info(std::string_view msg);
+void info(std::string_view p_msg);
 /// This function is not supposed to be called directly from library code, use LOG_WARNING(...)
 /// instead.
-void Warning(std::string_view msg);
+void warning(std::string_view p_msg);
 /// This function is not supposed to be called directly from library code, use LOG_ERROR(...)
 /// instead.
-void Error(std::string_view msg);
+void error(std::string_view p_msg);
 /// Inject callbacks to receive log messages for the respective log level.
 /// If not explicitly set all logging calls are effectively no-ops.
 /// Note: To unset the log callback call this function with an empty LogCallback
 ///       e.g. SetCallback(Logging::Level::Debug, Logging::LogCallback{});
 /// @param log_level to receive messages for
 /// @param callback function to call with log message
-void SetCallback(Level log_level, LogCallback callback);
+void setCallback(Level p_level, LogCallback p_callback);
 
 } // namespace jps::Logging
 
@@ -47,23 +47,23 @@ void SetCallback(Level log_level, LogCallback callback);
 #define __LOG(Level, FormatString, ...)                                                            \
     Logging::Level(fmt::format(FMT_STRING(FormatString), __VA_ARGS__))
 // NOLINTNEXTLINE
-#define LOG_DEBUG(FormatString, ...) __LOG(Debug, FormatString, __VA_ARGS__)
+#define LOG_DEBUG(FormatString, ...) __LOG(debug, FormatString, __VA_ARGS__)
 // NOLINTNEXTLINE
-#define LOG_INFO(FormatString, ...) __LOG(Info, FormatString, __VA_ARGS__)
+#define LOG_INFO(FormatString, ...) __LOG(info, FormatString, __VA_ARGS__)
 // NOLINTNEXTLINE
-#define LOG_WARNING(FormatString, ...) __LOG(Warning, FormatString, __VA_ARGS__)
+#define LOG_WARNING(FormatString, ...) __LOG(warning, FormatString, __VA_ARGS__)
 // NOLINTNEXTLINE
-#define LOG_ERROR(FormatString, ...) __LOG(Error, FormatString, __VA_ARGS__)
+#define LOG_ERROR(FormatString, ...) __LOG(error, FormatString, __VA_ARGS__)
 #else
 // NOLINTNEXTLINE
 #define __LOG(Level, FormatString, ...)                                                            \
     Logging::Level(fmt::format(FMT_STRING(FormatString), ##__VA_ARGS__))
 // NOLINTNEXTLINE
-#define LOG_DEBUG(FormatString, ...) __LOG(Debug, FormatString, ##__VA_ARGS__)
+#define LOG_DEBUG(FormatString, ...) __LOG(debug, FormatString, ##__VA_ARGS__)
 // NOLINTNEXTLINE
-#define LOG_INFO(FormatString, ...) __LOG(Info, FormatString, ##__VA_ARGS__)
+#define LOG_INFO(FormatString, ...) __LOG(info, FormatString, ##__VA_ARGS__)
 // NOLINTNEXTLINE
-#define LOG_WARNING(FormatString, ...) __LOG(Warning, FormatString, ##__VA_ARGS__)
+#define LOG_WARNING(FormatString, ...) __LOG(warning, FormatString, ##__VA_ARGS__)
 // NOLINTNEXTLINE
-#define LOG_ERROR(FormatString, ...) __LOG(Error, FormatString, ##__VA_ARGS__)
+#define LOG_ERROR(FormatString, ...) __LOG(error, FormatString, ##__VA_ARGS__)
 #endif

--- a/cpp/libcore/test/.clang-tidy
+++ b/cpp/libcore/test/.clang-tidy
@@ -32,9 +32,9 @@ CheckOptions:
     value: camelBack
   - key: readability-identifier-naming.MemberCase
     value: lower_case
-  - key: readability-identifier-naming.PublicMemberPrefix
-    value:
-  - key: readability-identifier-naming.MemberPrefix
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.ProtectedMemberPrefix
     value: m_
   - key: readability-identifier-naming.VariableCase
     value: lower_case

--- a/cpp/pycore/source/simulator_binding.cpp
+++ b/cpp/pycore/source/simulator_binding.cpp
@@ -23,7 +23,7 @@ PYBIND11_MODULE(jpscore, m)
     m_logging.def(
         "set_callback",
         [](jps::Logging::Level level, jps::Logging::LogCallback callback) {
-            jps::Logging::SetCallback(
+            jps::Logging::setCallback(
                 level, [callback = std::move(callback)](std::string_view msg) {
                     py::gil_scoped_acquire lock;
                     callback(msg);
@@ -38,9 +38,9 @@ PYBIND11_MODULE(jpscore, m)
     /// on shutdown registering an atexit handler is probably the most robust way to ensure
     /// destruction.
     py::module_::import("atexit").attr("register")(py::cpp_function([]() {
-        jps::Logging::SetCallback(jps::Logging::Level::Debug, jps::Logging::LogCallback{});
-        jps::Logging::SetCallback(jps::Logging::Level::Info, jps::Logging::LogCallback{});
-        jps::Logging::SetCallback(jps::Logging::Level::Warning, jps::Logging::LogCallback{});
-        jps::Logging::SetCallback(jps::Logging::Level::Error, jps::Logging::LogCallback{});
+        jps::Logging::setCallback(jps::Logging::Level::Debug, jps::Logging::LogCallback{});
+        jps::Logging::setCallback(jps::Logging::Level::Info, jps::Logging::LogCallback{});
+        jps::Logging::setCallback(jps::Logging::Level::Warning, jps::Logging::LogCallback{});
+        jps::Logging::setCallback(jps::Logging::Level::Error, jps::Logging::LogCallback{});
     }));
 }


### PR DESCRIPTION
Clang tidy config was broken. Unfortunately this didn't result in an
error and the new naming scheme was not checked. I fixed the config and
changed all names to the corresponding new scheme.

This could be the place for rediscussing the naming scheme ;).