### PR TITLE
Dummy pytest for enabling pytest in CI

### DIFF
--- a/jps/jupedsim/tests/test_dummy.py
+++ b/jps/jupedsim/tests/test_dummy.py
@@ -1,0 +1,8 @@
+"""
+pytest will emit error code 5 if there was no test run.
+For the CI we use this dummy test to check if the test infrastructure is working.
+"""
+
+
+def test_dummy_CI():
+    pass


### PR DESCRIPTION
pytest will emit error code 5 if there was no test run. 
To enable pytest in the CI we need a dummy test to avoid this error return. 
This error return makes sense to detect if tests are missing or some configuration is wrong. 