### PR TITLE
LengthUnit implementation

### DIFF
--- a/cpp/libcore/source/CMakeLists.txt
+++ b/cpp/libcore/source/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(core
 
     util/identifiable.hpp
 
+    geometry/length_unit.hpp
+
     math/int_pow.hpp
 )
 

--- a/cpp/libcore/source/CMakeLists.txt
+++ b/cpp/libcore/source/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(core
     simulation.hpp
 
     util/identifiable.hpp
+
+    math/int_pow.hpp
 )
 
 target_include_directories(core

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -18,20 +18,16 @@ namespace details
 /// Scales the given quantity of a length unit from `from` unit to `to` unit.
 /// The used  quantity type T can be deduced automatically.
 /// If from < to the quantity is divided and truncated towards zero for integral T.
-/// Integer overflow is not checked.
 /// Can be called like: `scaleQuantity<Units::mm, Units::cm>(10)`
-/// @tparam T should be of integral type
 template <Units from, Units to, typename T>
 constexpr T scaleQuantity(T p_quantity)
 {
-    static_assert(std::is_integral_v<T>, "T in scaleQuantity() should be of integral type.");
-
     const int diff_exp = toUnderlying(from) - toUnderlying(to);
 
     if constexpr(diff_exp < 0) {
-        return p_quantity / jps::math::intPow<T, DECIMAL_BASE, -diff_exp>();
+        return p_quantity / jps::math::intPow<DECIMAL_BASE, -diff_exp>();
     } else {
-        return p_quantity * jps::math::intPow<T, DECIMAL_BASE, diff_exp>();
+        return p_quantity * jps::math::intPow<DECIMAL_BASE, diff_exp>();
     }
 }
 

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -91,13 +91,25 @@ public:
 
 
 private:
-    // Stores the length unit quantity in micro meter
+    // Stores the length unit quantity stored in RESOLUTION
     QuantityType m_quantity{};
 
     /// friend functions
     friend jps::LengthUnit operator-(jps::LengthUnit p_lu)
     {
         p_lu.m_quantity = -p_lu.m_quantity;
+        return p_lu;
+    }
+
+    friend jps::LengthUnit operator*(jps::LengthUnit p_lu, double p_scalar)
+    {
+        p_lu.m_quantity *= p_scalar;
+        return p_lu;
+    }
+
+    friend jps::LengthUnit operator/(jps::LengthUnit p_lu, double p_scalar)
+    {
+        p_lu.m_quantity /= p_scalar;
         return p_lu;
     }
 };
@@ -124,6 +136,10 @@ inline jps::LengthUnit operator-(jps::LengthUnit p_lhs, jps::LengthUnit const & 
     return p_lhs;
 }
 
+inline jps::LengthUnit operator*(double p_scalar, jps::LengthUnit p_lu)
+{
+    return p_lu * p_scalar;
+}
 /// User defined literals for all units
 inline jps::LengthUnit operator"" _um(long double p_quantity)
 {

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -10,7 +10,7 @@ namespace jps
 {
 /// Enumeration for supported length units.
 /// Underlying integer must be set to the decimal exponent relative to meter (like SI).
-enum class Units { mum = -6, mm = -3, cm = -2, dm = -1, m = 0, km = 3 };
+enum class Units { um = -6, mm = -3, cm = -2, dm = -1, m = 0, km = 3 };
 const int DECIMAL_BASE = 10;
 
 namespace details
@@ -57,7 +57,7 @@ class LengthUnit
 public:
     using QuantityType = std::int_least64_t;
 
-    const static Units RESOLUTION = Units::mum;
+    const static Units RESOLUTION = Units::um;
 
     LengthUnit() = default;
 
@@ -110,9 +110,9 @@ inline jps::LengthUnit operator+(jps::LengthUnit p_lhs, jps::LengthUnit const & 
 }
 
 /// User defined literals for all units
-inline jps::LengthUnit operator"" _mum(unsigned long long p_quantity)
+inline jps::LengthUnit operator"" _um(unsigned long long p_quantity)
 {
-    return jps::makeLengthUnit<jps::Units::mum>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::um>(p_quantity);
 }
 inline jps::LengthUnit operator"" _mm(unsigned long long p_quantity)
 {

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -83,6 +83,13 @@ public:
         return details::scaleQuantity<RESOLUTION, unit>(m_quantity);
     }
 
+    LengthUnit & operator+=(LengthUnit const & p_other) noexcept
+    {
+        m_quantity += p_other.m_quantity;
+        return *this;
+    }
+
+
 private:
     // Stores the length unit quantity in micro meter
     QuantityType m_quantity{};
@@ -95,3 +102,35 @@ LengthUnit makeLengthUnit(LengthUnit::QuantityType p_quantity)
 }
 
 } // namespace jps
+
+inline jps::LengthUnit operator+(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs)
+{
+    p_lhs += p_rhs;
+    return p_lhs;
+}
+
+/// User defined literals for all units
+inline jps::LengthUnit operator"" _mum(unsigned long long p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::mum>(p_quantity);
+}
+inline jps::LengthUnit operator"" _mm(unsigned long long p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::mm>(p_quantity);
+}
+inline jps::LengthUnit operator"" _cm(unsigned long long p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::cm>(p_quantity);
+}
+inline jps::LengthUnit operator"" _dm(unsigned long long p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::dm>(p_quantity);
+}
+inline jps::LengthUnit operator"" _m(unsigned long long p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::m>(p_quantity);
+}
+inline jps::LengthUnit operator"" _km(unsigned long long p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::km>(p_quantity);
+}

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -19,7 +19,7 @@ namespace details
 /// If from < to the quantity is divided and truncated towards zero for integral T.
 /// Can be called like: `scaleQuantity<Units::mm, Units::cm>(10)`
 template <Units from, Units to, typename T>
-constexpr T scaleQuantity(T p_quantity)
+constexpr auto scaleQuantity(T p_quantity) -> T
 {
     const int diff_exp = toUnderlying(from) - toUnderlying(to);
 
@@ -36,10 +36,10 @@ struct LengthUnitParams {
 
     LengthUnitParams()                                 = delete;
     LengthUnitParams(LengthUnitParams const & p_other) = delete;
-    LengthUnitParams & operator=(LengthUnitParams const & p_other) = delete;
+    auto operator=(LengthUnitParams const & p_other) -> LengthUnitParams & = delete;
 
     LengthUnitParams(LengthUnitParams && p_other) noexcept = default;
-    LengthUnitParams & operator=(LengthUnitParams && p_other) noexcept = default;
+    auto operator=(LengthUnitParams && p_other) noexcept -> LengthUnitParams & = default;
 
     ~LengthUnitParams() = default;
 
@@ -58,10 +58,10 @@ public:
     LengthUnit() = default;
 
     LengthUnit(LengthUnit const & p_other) = default;
-    LengthUnit & operator=(LengthUnit const & p_other) = default;
+    auto operator=(LengthUnit const & p_other) -> LengthUnit & = default;
 
     LengthUnit(LengthUnit && p_moved) noexcept = default;
-    LengthUnit & operator=(LengthUnit && p_moved) noexcept = default;
+    auto operator=(LengthUnit && p_moved) noexcept -> LengthUnit & = default;
 
     ~LengthUnit() = default;
 
@@ -72,18 +72,18 @@ public:
     }
 
     template <Units unit = RESOLUTION>
-    QuantityType get() const
+    auto get() const -> QuantityType
     {
         return details::scaleQuantity<RESOLUTION, unit>(m_quantity);
     }
 
-    LengthUnit & operator+=(LengthUnit const & p_other) noexcept
+    auto operator+=(LengthUnit const & p_other) noexcept -> LengthUnit &
     {
         m_quantity += p_other.m_quantity;
         return *this;
     }
 
-    LengthUnit & operator-=(LengthUnit const & p_other) noexcept
+    auto operator-=(LengthUnit const & p_other) noexcept -> LengthUnit &
     {
         m_quantity -= p_other.m_quantity;
         return *this;
@@ -95,19 +95,19 @@ private:
     QuantityType m_quantity{};
 
     /// friend functions
-    friend jps::LengthUnit operator-(jps::LengthUnit p_lu)
+    friend auto operator-(jps::LengthUnit p_lu) -> jps::LengthUnit
     {
         p_lu.m_quantity = -p_lu.m_quantity;
         return p_lu;
     }
 
-    friend jps::LengthUnit operator*(jps::LengthUnit p_lu, double p_scalar)
+    friend auto operator*(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit
     {
         p_lu.m_quantity *= p_scalar;
         return p_lu;
     }
 
-    friend jps::LengthUnit operator/(jps::LengthUnit p_lu, double p_scalar)
+    friend auto operator/(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit
     {
         p_lu.m_quantity /= p_scalar;
         return p_lu;
@@ -115,7 +115,7 @@ private:
 };
 
 template <Units Unit>
-LengthUnit makeLengthUnit(LengthUnit::QuantityType p_quantity)
+auto makeLengthUnit(LengthUnit::QuantityType p_quantity) -> LengthUnit
 {
     return LengthUnit{details::LengthUnitParams<LengthUnit::QuantityType, Unit>{p_quantity}};
 }
@@ -124,70 +124,70 @@ LengthUnit makeLengthUnit(LengthUnit::QuantityType p_quantity)
 
 
 /// arithmetic operations
-inline jps::LengthUnit operator+(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs)
+inline auto operator+(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs) -> jps::LengthUnit
 {
     p_lhs += p_rhs;
     return p_lhs;
 }
 
-inline jps::LengthUnit operator-(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs)
+inline auto operator-(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs) -> jps::LengthUnit
 {
     p_lhs -= p_rhs;
     return p_lhs;
 }
 
-inline jps::LengthUnit operator*(double p_scalar, jps::LengthUnit p_lu)
+inline auto operator*(double p_scalar, jps::LengthUnit p_lu) -> jps::LengthUnit
 {
     return p_lu * p_scalar;
 }
 /// User defined literals for all units
-inline jps::LengthUnit operator"" _um(long double p_quantity)
+inline auto operator"" _um(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::um>(p_quantity);
 }
-inline jps::LengthUnit operator"" _mm(long double p_quantity)
+inline auto operator"" _mm(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::mm>(p_quantity);
 }
-inline jps::LengthUnit operator"" _cm(long double p_quantity)
+inline auto operator"" _cm(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::cm>(p_quantity);
 }
-inline jps::LengthUnit operator"" _dm(long double p_quantity)
+inline auto operator"" _dm(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::dm>(p_quantity);
 }
-inline jps::LengthUnit operator"" _m(long double p_quantity)
+inline auto operator"" _m(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::m>(p_quantity);
 }
-inline jps::LengthUnit operator"" _km(long double p_quantity)
+inline auto operator"" _km(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::km>(p_quantity);
 }
 
 /// User defined literals for integrals
-inline jps::LengthUnit operator"" _um(unsigned long long p_quantity)
+inline auto operator"" _um(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::um>(p_quantity);
 }
-inline jps::LengthUnit operator"" _mm(unsigned long long p_quantity)
+inline auto operator"" _mm(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::mm>(p_quantity);
 }
-inline jps::LengthUnit operator"" _cm(unsigned long long p_quantity)
+inline auto operator"" _cm(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::cm>(p_quantity);
 }
-inline jps::LengthUnit operator"" _dm(unsigned long long p_quantity)
+inline auto operator"" _dm(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::dm>(p_quantity);
 }
-inline jps::LengthUnit operator"" _m(unsigned long long p_quantity)
+inline auto operator"" _m(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::m>(p_quantity);
 }
-inline jps::LengthUnit operator"" _km(unsigned long long p_quantity)
+inline auto operator"" _km(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::km>(p_quantity);
 }

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -83,10 +83,23 @@ public:
         return *this;
     }
 
+    LengthUnit & operator-=(LengthUnit const & p_other) noexcept
+    {
+        m_quantity -= p_other.m_quantity;
+        return *this;
+    }
+
 
 private:
     // Stores the length unit quantity in micro meter
     QuantityType m_quantity{};
+
+    /// friend functions
+    friend jps::LengthUnit operator-(jps::LengthUnit p_lu)
+    {
+        p_lu.m_quantity = -p_lu.m_quantity;
+        return p_lu;
+    }
 };
 
 template <Units Unit>
@@ -97,9 +110,17 @@ LengthUnit makeLengthUnit(LengthUnit::QuantityType p_quantity)
 
 } // namespace jps
 
+
+/// arithmetic operations
 inline jps::LengthUnit operator+(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs)
 {
     p_lhs += p_rhs;
+    return p_lhs;
+}
+
+inline jps::LengthUnit operator-(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs)
+{
+    p_lhs -= p_rhs;
     return p_lhs;
 }
 

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "enum.hpp"
+#include "math/int_pow.hpp"
+
+#include <cstdint>
+#include <type_traits>
+
+namespace jps
+{
+/// Enumeration for supported length units.
+/// Underlying integer must be set to the decimal exponent relative to meter (like SI).
+enum class Units { mum = -6, mm = -3, cm = -2, dm = -1, m = 0, km = 3 };
+const int DECIMAL_BASE = 10;
+
+namespace details
+{
+/// Scales the given quantity of a length unit from `from` unit to `to` unit.
+/// The used  quantity type T can be deduced automatically.
+/// If from < to the quantity is divided and truncated towards zero for integral T.
+/// Integer overflow is not checked.
+/// Can be called like: `scaleQuantity<Units::mm, Units::cm>(10)`
+/// @tparam T should be of integral type
+template <Units from, Units to, typename T>
+constexpr T scaleQuantity(T p_quantity)
+{
+    static_assert(std::is_integral_v<T>, "T in scaleQuantity() should be of integral type.");
+
+    const int diff_exp = toUnderlying(from) - toUnderlying(to);
+
+    if constexpr(diff_exp < 0) {
+        return p_quantity / jps::math::intPow<T, DECIMAL_BASE, -diff_exp>();
+    } else {
+        return p_quantity * jps::math::intPow<T, DECIMAL_BASE, diff_exp>();
+    }
+}
+} // namespace details
+} // namespace jps

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -109,6 +109,25 @@ public:
         return *this;
     }
 
+    auto operator<(LengthUnit const & p_other) const noexcept -> bool
+    {
+        return m_quantity < p_other.m_quantity;
+    }
+
+    auto operator>(LengthUnit const & p_other) const noexcept -> bool
+    {
+        return m_quantity > p_other.m_quantity;
+    }
+
+    auto operator==(LengthUnit const & p_other) const noexcept -> bool
+    {
+        return m_quantity == p_other.m_quantity;
+    }
+
+    auto operator!=(LengthUnit const & p_other) const noexcept -> bool
+    {
+        return m_quantity != p_other.m_quantity;
+    }
 
 private:
     /// Stores the length unit quantity stored in RESOLUTION

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -34,29 +34,31 @@ constexpr auto scaleQuantity(T p_quantity) -> T
     }
 }
 
+
+/// Helper struct to encapsulate the params required for LengthUnit construction
+/// @tparam QuantityType floating point type used to represent the quantity
+/// @tparam Unit of the quantity
 template <typename QuantityType, Units Unit>
 struct LengthUnitParams {
+    /// The quantity for the LengthUnit creation in Unit
     const QuantityType quantity; // NOLINT(misc-non-private-member-variables-in-classes)
-
-    LengthUnitParams()                                 = delete;
-    LengthUnitParams(LengthUnitParams const & p_other) = delete;
-    auto operator=(LengthUnitParams const & p_other) -> LengthUnitParams & = delete;
-
-    LengthUnitParams(LengthUnitParams && p_other) noexcept = default;
-    auto operator=(LengthUnitParams && p_other) noexcept -> LengthUnitParams & = default;
-
-    ~LengthUnitParams() = default;
-
     LengthUnitParams(QuantityType p_quantity) : quantity{p_quantity} {}
 };
 } // namespace details
 
+/// Stores the quantity of a length unit
+///
+/// LengthUnit is the base unit for all spatial data structures.
+/// It represents a quantity in RESOLUTION unit.
+/// It can only be created by explicitly passing the unit of the quantity.
+/// The construction has to be done using LengthUnitParams.
 class LengthUnit
 {
     /// Defines the unit which is used to store the quantity internally
     const static Units RESOLUTION = Units::m;
 
 public:
+    /// Type used for the quantity.
     using QuantityType = double;
 
     LengthUnit() = default;
@@ -69,16 +71,30 @@ public:
 
     ~LengthUnit() = default;
 
+    /// Constructors using LengthUnitParams
+    ///
+    /// Template parameters in constructors have to be auto deducible.
+    /// Otherwise it is not possible to distinguish class template params and constructor template
+    /// params.
+    /// The quantity is scaled towards the RESOLUTION unit.
+    ///
+    /// @tparam Unit is the input unit of the quantity.
     template <Units Unit>
     LengthUnit(details::LengthUnitParams<QuantityType, Unit> const & p_params) :
         m_quantity{details::scaleQuantity<Unit, RESOLUTION>(p_params.quantity)}
     {
     }
 
-    template <Units unit = RESOLUTION>
+    /// Retrieves the quantity in the desired Unit
+    ///
+    /// The quantity will be scaled to the target Unit.
+    ///
+    /// @tparam Unit target unit for the quantity
+    /// @returns the quantity in the target Unit
+    template <Units Unit = RESOLUTION>
     auto get() const -> QuantityType
     {
-        return details::scaleQuantity<RESOLUTION, unit>(m_quantity);
+        return details::scaleQuantity<RESOLUTION, Unit>(m_quantity);
     }
 
     auto operator+=(LengthUnit const & p_other) noexcept -> LengthUnit &
@@ -95,10 +111,10 @@ public:
 
 
 private:
-    // Stores the length unit quantity stored in RESOLUTION
+    /// Stores the length unit quantity stored in RESOLUTION
     QuantityType m_quantity{};
 
-    /// friend functions
+    // friend functions
     friend auto operator-(jps::LengthUnit p_lu) -> jps::LengthUnit
     {
         p_lu.m_quantity = -p_lu.m_quantity;
@@ -118,6 +134,11 @@ private:
     }
 };
 
+/// Helper for creating LengthUnit
+///
+/// @tparam Unit is the input Unit of p_quantity
+/// @param p_quantity the quantity of the LengthUnit
+/// @returns LengthUnit with the quantity
 template <Units Unit>
 auto makeLengthUnit(LengthUnit::QuantityType p_quantity) -> LengthUnit
 {

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -49,11 +49,11 @@ struct LengthUnitParams {
 
 class LengthUnit
 {
-public:
-    using QuantityType = double;
-
     /// Defines the unit which is used to store the quantity internally
     const static Units RESOLUTION = Units::m;
+
+public:
+    using QuantityType = double;
 
     LengthUnit() = default;
 

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -3,7 +3,6 @@
 #include "enum.hpp"
 #include "math/int_pow.hpp"
 
-#include <cstdint>
 #include <type_traits>
 
 namespace jps
@@ -51,9 +50,10 @@ struct LengthUnitParams {
 class LengthUnit
 {
 public:
-    using QuantityType = std::int_least64_t;
+    using QuantityType = double;
 
-    const static Units RESOLUTION = Units::um;
+    /// Defines the unit which is used to store the quantity internally
+    const static Units RESOLUTION = Units::m;
 
     LengthUnit() = default;
 
@@ -104,6 +104,32 @@ inline jps::LengthUnit operator+(jps::LengthUnit p_lhs, jps::LengthUnit const & 
 }
 
 /// User defined literals for all units
+inline jps::LengthUnit operator"" _um(long double p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::um>(p_quantity);
+}
+inline jps::LengthUnit operator"" _mm(long double p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::mm>(p_quantity);
+}
+inline jps::LengthUnit operator"" _cm(long double p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::cm>(p_quantity);
+}
+inline jps::LengthUnit operator"" _dm(long double p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::dm>(p_quantity);
+}
+inline jps::LengthUnit operator"" _m(long double p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::m>(p_quantity);
+}
+inline jps::LengthUnit operator"" _km(long double p_quantity)
+{
+    return jps::makeLengthUnit<jps::Units::km>(p_quantity);
+}
+
+/// User defined literals for integrals
 inline jps::LengthUnit operator"" _um(unsigned long long p_quantity)
 {
     return jps::makeLengthUnit<jps::Units::um>(p_quantity);

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -21,6 +21,10 @@ namespace details
 template <Units from, Units to, typename T>
 constexpr auto scaleQuantity(T p_quantity) -> T
 {
+    static_assert(
+        std::is_floating_point_v<T>,
+        "scaleQuantity should be used with floating point types only.");
+
     const int diff_exp = toUnderlying(from) - toUnderlying(to);
 
     if constexpr(diff_exp < 0) {

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -34,5 +34,64 @@ constexpr T scaleQuantity(T p_quantity)
         return p_quantity * jps::math::intPow<T, DECIMAL_BASE, diff_exp>();
     }
 }
+
+template <typename QuantityType, Units Unit>
+struct LengthUnitParams {
+    const QuantityType quantity; // NOLINT(misc-non-private-member-variables-in-classes)
+
+    LengthUnitParams()                                 = delete;
+    LengthUnitParams(LengthUnitParams const & p_other) = delete;
+    LengthUnitParams & operator=(LengthUnitParams const & p_other) = delete;
+
+    LengthUnitParams(LengthUnitParams && p_other) noexcept = default;
+    LengthUnitParams & operator=(LengthUnitParams && p_other) noexcept = default;
+
+    ~LengthUnitParams() = default;
+
+    LengthUnitParams(QuantityType p_quantity) : quantity{p_quantity} {}
+};
 } // namespace details
+
+class LengthUnit
+{
+public:
+    using QuantityType = std::int_least64_t;
+
+    const static Units RESOLUTION = Units::mum;
+
+    LengthUnit() = default;
+
+    LengthUnit(LengthUnit const & p_other) = default;
+    LengthUnit & operator=(LengthUnit const & p_other) = default;
+
+    LengthUnit(LengthUnit && p_moved) noexcept = default;
+    LengthUnit & operator=(LengthUnit && p_moved) noexcept = default;
+
+    ~LengthUnit() = default;
+
+    template <Units Unit>
+    LengthUnit(details::LengthUnitParams<QuantityType, Unit> const & p_params) :
+        m_quantity{details::scaleQuantity<Unit, RESOLUTION>(p_params.quantity)}
+    {
+    }
+
+    bool operator==(QuantityType p_other) const { return m_quantity == p_other; }
+
+    template <Units unit = RESOLUTION>
+    QuantityType get() const
+    {
+        return details::scaleQuantity<RESOLUTION, unit>(m_quantity);
+    }
+
+private:
+    // Stores the length unit quantity in micro meter
+    QuantityType m_quantity{};
+};
+
+template <Units Unit>
+LengthUnit makeLengthUnit(LengthUnit::QuantityType p_quantity)
+{
+    return LengthUnit{details::LengthUnitParams<LengthUnit::QuantityType, Unit>{p_quantity}};
+}
+
 } // namespace jps

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -75,8 +75,6 @@ public:
     {
     }
 
-    bool operator==(QuantityType p_other) const { return m_quantity == p_other; }
-
     template <Units unit = RESOLUTION>
     QuantityType get() const
     {

--- a/cpp/libcore/source/math/int_pow.hpp
+++ b/cpp/libcore/source/math/int_pow.hpp
@@ -9,7 +9,7 @@ namespace jps::math
 /// @tparam int base
 /// @tparam exp exponent as unsigned short
 template <int base, unsigned short exp>
-constexpr int intPow()
+constexpr auto intPow() -> int
 {
     if constexpr(exp == 0) {
         return 1;

--- a/cpp/libcore/source/math/int_pow.hpp
+++ b/cpp/libcore/source/math/int_pow.hpp
@@ -4,20 +4,17 @@
 
 namespace jps::math
 {
-/// intPow() creates a lookup table for integral base to the power of integral exponent
+/// intPow() creates a lookup table for int base to the power of integral exponent
 /// Must be used with non-type template parameters.
-/// @tparam T underlying integral type.
-/// @tparam base must be of integral type T
+/// @tparam int base
 /// @tparam exp exponent as unsigned short
-template <typename T, T base, unsigned short exp>
-constexpr T intPow()
+template <int base, unsigned short exp>
+constexpr int intPow()
 {
-    static_assert(std::is_integral<T>(), "intPow() underlying type must be integral.");
-
     if constexpr(exp == 0) {
         return 1;
     } else {
-        return base * intPow<T, base, exp - 1>();
+        return base * intPow<base, exp - 1>();
     }
 }
 } // namespace jps::math

--- a/cpp/libcore/source/math/int_pow.hpp
+++ b/cpp/libcore/source/math/int_pow.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <type_traits>
+
+namespace jps::math
+{
+/// intPow() creates a lookup table for integral base to the power of integral exponent
+/// Must be used with non-type template parameters.
+/// @tparam T underlying integral type.
+/// @tparam base must be of integral type T
+/// @tparam exp exponent as unsigned short
+template <typename T, T base, unsigned short exp>
+constexpr T intPow()
+{
+    static_assert(std::is_integral<T>(), "intPow() underlying type must be integral.");
+
+    if constexpr(exp == 0) {
+        return 1;
+    } else {
+        return base * intPow<T, base, exp - 1>();
+    }
+}
+} // namespace jps::math

--- a/cpp/libcore/test/.clang-tidy
+++ b/cpp/libcore/test/.clang-tidy
@@ -11,7 +11,9 @@ Checks: >-
   -modernize-use-nodiscard,
   performance-*,
   portability-*,
-  readability-*
+  readability-*,
+  -readability-magic-numbers,
+  -cppcoreguidelines-avoid-magic-numbers
 WarningsAsErrors:    '*'
 HeaderFilterRegex:   '.*'
 FormatStyle:         file

--- a/cpp/libcore/test/CMakeLists.txt
+++ b/cpp/libcore/test/CMakeLists.txt
@@ -3,6 +3,8 @@ add_executable(test-core
     test_dependency_availability.cpp
 
     util/test_identifiable.cpp
+
+    math/test_int_pow.cpp
 )
 
 target_link_libraries(test-core

--- a/cpp/libcore/test/CMakeLists.txt
+++ b/cpp/libcore/test/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(test-core
 
     util/test_identifiable.cpp
 
+    geometry/test_length_unit.cpp
+
     math/test_int_pow.cpp
 )
 

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -1,0 +1,51 @@
+#include "geometry/length_unit.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(LengthUnit, scaleQuantity)
+{
+    using namespace jps;
+    using namespace details;
+
+    // From km
+    EXPECT_EQ((scaleQuantity<Units::km, Units::mum>(1)), 1000000000);
+    EXPECT_EQ((scaleQuantity<Units::km, Units::mm>(1)), 1000000);
+    EXPECT_EQ((scaleQuantity<Units::km, Units::cm>(1)), 100000);
+    EXPECT_EQ((scaleQuantity<Units::km, Units::dm>(1)), 10000);
+    EXPECT_EQ((scaleQuantity<Units::km, Units::m>(1)), 1000);
+
+    // From m
+    EXPECT_EQ((scaleQuantity<Units::m, Units::km>(1200)), 1);
+    EXPECT_EQ((scaleQuantity<Units::m, Units::dm>(2)), 20);
+    EXPECT_EQ((scaleQuantity<Units::m, Units::cm>(2)), 200);
+    EXPECT_EQ((scaleQuantity<Units::m, Units::mm>(2)), 2000);
+    EXPECT_EQ((scaleQuantity<Units::m, Units::mum>(2)), 2000000);
+
+    // From dm
+    EXPECT_EQ((scaleQuantity<Units::dm, Units::km>(20000)), 2);
+    EXPECT_EQ((scaleQuantity<Units::dm, Units::m>(19)), 1);
+    EXPECT_EQ((scaleQuantity<Units::dm, Units::cm>(1)), 10);
+    EXPECT_EQ((scaleQuantity<Units::dm, Units::mm>(1)), 100);
+    EXPECT_EQ((scaleQuantity<Units::dm, Units::mum>(1)), 100000);
+
+    // From cm
+    EXPECT_EQ((scaleQuantity<Units::cm, Units::km>(120000)), 1);
+    EXPECT_EQ((scaleQuantity<Units::cm, Units::m>(100)), 1);
+    EXPECT_EQ((scaleQuantity<Units::cm, Units::dm>(12)), 1);
+    EXPECT_EQ((scaleQuantity<Units::cm, Units::mm>(1)), 10);
+    EXPECT_EQ((scaleQuantity<Units::cm, Units::mum>(2)), 20000);
+
+    // From mm
+    EXPECT_EQ((scaleQuantity<Units::mm, Units::km>(5000000)), 5);
+    EXPECT_EQ((scaleQuantity<Units::mm, Units::m>(1200)), 1);
+    EXPECT_EQ((scaleQuantity<Units::mm, Units::dm>(540)), 5);
+    EXPECT_EQ((scaleQuantity<Units::mm, Units::cm>(78)), 7);
+    EXPECT_EQ((scaleQuantity<Units::mm, Units::mum>(5)), 5000);
+
+    // From mum
+    EXPECT_EQ((scaleQuantity<Units::mum, Units::km>(1234763874)), 1);
+    EXPECT_EQ((scaleQuantity<Units::mum, Units::m>(1846574)), 1);
+    EXPECT_EQ((scaleQuantity<Units::mum, Units::dm>(192837)), 1);
+    EXPECT_EQ((scaleQuantity<Units::mum, Units::cm>(13823)), 1);
+    EXPECT_EQ((scaleQuantity<Units::mum, Units::mm>(1234)), 1);
+}

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -98,6 +98,28 @@ TEST(LengthUnit, makeLengthUnit)
     EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1000).get<Units::mm>()), 1);
 }
 
+TEST(LengthUnit, UserDefinedLiterals)
+{
+    EXPECT_EQ((1_mum).get<jps::Units::mum>(), 1);
+    EXPECT_EQ((1_mm).get<jps::Units::mm>(), 1);
+    EXPECT_EQ((1_cm).get<jps::Units::cm>(), 1);
+    EXPECT_EQ((1_dm).get<jps::Units::dm>(), 1);
+    EXPECT_EQ((1_m).get<jps::Units::m>(), 1);
+    EXPECT_EQ((1_km).get<jps::Units::km>(), 1);
+}
+
+TEST(LengthUnit, arithmetics)
+{
+    using namespace jps;
+
+    auto lu       = makeLengthUnit<Units::mm>(1);
+    auto other_lu = makeLengthUnit<Units::mum>(1);
+
+    lu += other_lu;
+    EXPECT_EQ(lu.get(), 1001);
+    EXPECT_EQ(other_lu.get(), 1);
+}
+
 
 TEST(LengthUnit, scaleQuantity)
 {

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -71,6 +71,34 @@ TEST(LengthUnit, NonHelperConstruction)
         1);
 }
 
+TEST(LengthUnit, makeLengthUnit)
+{
+    using namespace jps;
+    using namespace details;
+    // Same unit
+    EXPECT_EQ((makeLengthUnit<Units::km>(10).get<Units::km>()), 10);
+    EXPECT_EQ((makeLengthUnit<Units::m>(10).get<Units::m>()), 10);
+    EXPECT_EQ((makeLengthUnit<Units::dm>(10).get<Units::dm>()), 10);
+    EXPECT_EQ((makeLengthUnit<Units::cm>(10).get<Units::cm>()), 10);
+    EXPECT_EQ((makeLengthUnit<Units::mm>(10).get<Units::mm>()), 10);
+    EXPECT_EQ((makeLengthUnit<Units::mum>(10).get<Units::mum>()), 10);
+
+    // Check if scaling is used in constructor
+    EXPECT_EQ((makeLengthUnit<Units::km>(1).get<LengthUnit::RESOLUTION>()), 1000000000);
+    EXPECT_EQ((makeLengthUnit<Units::m>(1).get<LengthUnit::RESOLUTION>()), 1000000);
+    EXPECT_EQ((makeLengthUnit<Units::dm>(1).get<LengthUnit::RESOLUTION>()), 100000);
+    EXPECT_EQ((makeLengthUnit<Units::cm>(1).get<LengthUnit::RESOLUTION>()), 10000);
+    EXPECT_EQ((makeLengthUnit<Units::mm>(1).get<LengthUnit::RESOLUTION>()), 1000);
+
+    // Check if scaling is used in get method
+    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1000000000).get<Units::km>()), 1);
+    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1000000).get<Units::m>()), 1);
+    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(100000).get<Units::dm>()), 1);
+    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(10000).get<Units::cm>()), 1);
+    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1000).get<Units::mm>()), 1);
+}
+
+
 TEST(LengthUnit, scaleQuantity)
 {
     using namespace jps;

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -192,7 +192,47 @@ TEST(LengthUnit, arithmetics)
     EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 10.);
 }
 
+TEST(LengthUnit, comparisonOperators)
+{
+    using namespace jps;
+    using namespace details;
 
+    // ==
+    EXPECT_TRUE(1_m == 1_m);
+    EXPECT_TRUE(1.000001_m == 1000001_um);
+    EXPECT_TRUE(1_m == 1000_mm);
+    EXPECT_TRUE(1_km == 1000000000_um);
+    EXPECT_TRUE(1.0_m == 1_m);
+
+    EXPECT_FALSE(1_m == 1_cm);
+    EXPECT_FALSE(999_cm == 999.00001_cm);
+
+    // !=
+    EXPECT_TRUE(1_m != 2_m);
+    EXPECT_TRUE(1.000001_m != 1_m);
+    EXPECT_TRUE(1_m != 1_mm);
+
+    EXPECT_FALSE(100_m != 0.1_km);
+    EXPECT_FALSE(1_m != 1_m);
+
+    // <
+    EXPECT_TRUE(1._m < 2._m);
+    EXPECT_TRUE(1_mm < 1_cm);
+    EXPECT_TRUE(999_m < 1_km);
+
+    EXPECT_FALSE(2_m < 1_m);
+    EXPECT_FALSE(2_m < 1_cm);
+    EXPECT_FALSE(1_km < 999_m);
+
+    // >
+    EXPECT_TRUE(2_m > 1_m);
+    EXPECT_TRUE(2_m > 1_cm);
+    EXPECT_TRUE(1_km > 999_m);
+
+    EXPECT_FALSE(1._m > 2._m);
+    EXPECT_FALSE(1_mm > 1_cm);
+    EXPECT_FALSE(999_m > 1_km);
+}
 TEST(LengthUnit, scaleQuantity)
 {
     using namespace jps;

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -23,7 +23,7 @@ TEST(LengthUnit, NonHelperConstruction)
         (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mm>{10}}.get<Units::mm>()),
         10);
     EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mum>{10}}.get<Units::mum>()),
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::um>{10}}.get<Units::um>()),
         10);
 
     // Check if scaling is used in constructor
@@ -81,7 +81,7 @@ TEST(LengthUnit, makeLengthUnit)
     EXPECT_EQ((makeLengthUnit<Units::dm>(10).get<Units::dm>()), 10);
     EXPECT_EQ((makeLengthUnit<Units::cm>(10).get<Units::cm>()), 10);
     EXPECT_EQ((makeLengthUnit<Units::mm>(10).get<Units::mm>()), 10);
-    EXPECT_EQ((makeLengthUnit<Units::mum>(10).get<Units::mum>()), 10);
+    EXPECT_EQ((makeLengthUnit<Units::um>(10).get<Units::um>()), 10);
 
     // Check if scaling is used in constructor
     EXPECT_EQ((makeLengthUnit<Units::km>(1).get<LengthUnit::RESOLUTION>()), 1000000000);
@@ -100,7 +100,7 @@ TEST(LengthUnit, makeLengthUnit)
 
 TEST(LengthUnit, UserDefinedLiterals)
 {
-    EXPECT_EQ((1_mum).get<jps::Units::mum>(), 1);
+    EXPECT_EQ((1_um).get<jps::Units::um>(), 1);
     EXPECT_EQ((1_mm).get<jps::Units::mm>(), 1);
     EXPECT_EQ((1_cm).get<jps::Units::cm>(), 1);
     EXPECT_EQ((1_dm).get<jps::Units::dm>(), 1);
@@ -113,7 +113,7 @@ TEST(LengthUnit, arithmetics)
     using namespace jps;
 
     auto lu       = makeLengthUnit<Units::mm>(1);
-    auto other_lu = makeLengthUnit<Units::mum>(1);
+    auto other_lu = makeLengthUnit<Units::um>(1);
 
     lu += other_lu;
     EXPECT_EQ(lu.get(), 1001);
@@ -127,7 +127,7 @@ TEST(LengthUnit, scaleQuantity)
     using namespace details;
 
     // From km
-    EXPECT_EQ((scaleQuantity<Units::km, Units::mum>(1)), 1000000000);
+    EXPECT_EQ((scaleQuantity<Units::km, Units::um>(1)), 1000000000);
     EXPECT_EQ((scaleQuantity<Units::km, Units::mm>(1)), 1000000);
     EXPECT_EQ((scaleQuantity<Units::km, Units::cm>(1)), 100000);
     EXPECT_EQ((scaleQuantity<Units::km, Units::dm>(1)), 10000);
@@ -138,33 +138,33 @@ TEST(LengthUnit, scaleQuantity)
     EXPECT_EQ((scaleQuantity<Units::m, Units::dm>(2)), 20);
     EXPECT_EQ((scaleQuantity<Units::m, Units::cm>(2)), 200);
     EXPECT_EQ((scaleQuantity<Units::m, Units::mm>(2)), 2000);
-    EXPECT_EQ((scaleQuantity<Units::m, Units::mum>(2)), 2000000);
+    EXPECT_EQ((scaleQuantity<Units::m, Units::um>(2)), 2000000);
 
     // From dm
     EXPECT_EQ((scaleQuantity<Units::dm, Units::km>(20000)), 2);
     EXPECT_EQ((scaleQuantity<Units::dm, Units::m>(19)), 1);
     EXPECT_EQ((scaleQuantity<Units::dm, Units::cm>(1)), 10);
     EXPECT_EQ((scaleQuantity<Units::dm, Units::mm>(1)), 100);
-    EXPECT_EQ((scaleQuantity<Units::dm, Units::mum>(1)), 100000);
+    EXPECT_EQ((scaleQuantity<Units::dm, Units::um>(1)), 100000);
 
     // From cm
     EXPECT_EQ((scaleQuantity<Units::cm, Units::km>(120000)), 1);
     EXPECT_EQ((scaleQuantity<Units::cm, Units::m>(100)), 1);
     EXPECT_EQ((scaleQuantity<Units::cm, Units::dm>(12)), 1);
     EXPECT_EQ((scaleQuantity<Units::cm, Units::mm>(1)), 10);
-    EXPECT_EQ((scaleQuantity<Units::cm, Units::mum>(2)), 20000);
+    EXPECT_EQ((scaleQuantity<Units::cm, Units::um>(2)), 20000);
 
     // From mm
     EXPECT_EQ((scaleQuantity<Units::mm, Units::km>(5000000)), 5);
     EXPECT_EQ((scaleQuantity<Units::mm, Units::m>(1200)), 1);
     EXPECT_EQ((scaleQuantity<Units::mm, Units::dm>(540)), 5);
     EXPECT_EQ((scaleQuantity<Units::mm, Units::cm>(78)), 7);
-    EXPECT_EQ((scaleQuantity<Units::mm, Units::mum>(5)), 5000);
+    EXPECT_EQ((scaleQuantity<Units::mm, Units::um>(5)), 5000);
 
-    // From mum
-    EXPECT_EQ((scaleQuantity<Units::mum, Units::km>(1234763874)), 1);
-    EXPECT_EQ((scaleQuantity<Units::mum, Units::m>(1846574)), 1);
-    EXPECT_EQ((scaleQuantity<Units::mum, Units::dm>(192837)), 1);
-    EXPECT_EQ((scaleQuantity<Units::mum, Units::cm>(13823)), 1);
-    EXPECT_EQ((scaleQuantity<Units::mum, Units::mm>(1234)), 1);
+    // From um
+    EXPECT_EQ((scaleQuantity<Units::um, Units::km>(1234763874)), 1);
+    EXPECT_EQ((scaleQuantity<Units::um, Units::m>(1846574)), 1);
+    EXPECT_EQ((scaleQuantity<Units::um, Units::dm>(192837)), 1);
+    EXPECT_EQ((scaleQuantity<Units::um, Units::cm>(13823)), 1);
+    EXPECT_EQ((scaleQuantity<Units::um, Units::mm>(1234)), 1);
 }

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -8,67 +8,56 @@ TEST(LengthUnit, NonHelperConstruction)
     using namespace details;
 
     // Same unit
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::km>{10}}.get<Units::km>()),
-        10);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{10}}.get<Units::m>()), 10);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::dm>{10}}.get<Units::dm>()),
-        10);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::cm>{10}}.get<Units::cm>()),
-        10);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mm>{10}}.get<Units::mm>()),
-        10);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::um>{10}}.get<Units::um>()),
-        10);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::km>{10.}}.get<Units::km>()),
+        10.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{10.}}.get<Units::m>()),
+        10.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::dm>{10.}}.get<Units::dm>()),
+        10.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::cm>{10.}}.get<Units::cm>()),
+        10.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mm>{10.}}.get<Units::mm>()),
+        10.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::um>{10.}}.get<Units::um>()),
+        10.);
 
     // Check if scaling is used in constructor
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::km>{1}}
-             .get<LengthUnit::RESOLUTION>()),
-        1000000000);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{1}}
-             .get<LengthUnit::RESOLUTION>()),
-        1000000);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::dm>{1}}
-             .get<LengthUnit::RESOLUTION>()),
-        100000);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::cm>{1}}
-             .get<LengthUnit::RESOLUTION>()),
-        10000);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mm>{1}}
-             .get<LengthUnit::RESOLUTION>()),
-        1000);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::km>{1.}}.get<Units::m>()),
+        1e3);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{1.}}.get<Units::m>()), 1.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::dm>{1.}}.get<Units::m>()),
+        1e-1);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::cm>{1.}}.get<Units::m>()),
+        1e-2);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mm>{1.}}.get<Units::m>()),
+        1e-3);
 
     // Check if scaling is used in get method
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{1000000000}}
-             .get<Units::km>()),
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{1e3}}.get<Units::km>()),
         1);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{1000000}}
-             .get<Units::m>()),
-        1);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{100000}}
-             .get<Units::dm>()),
-        1);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{10000}}
-             .get<Units::cm>()),
-        1);
-    EXPECT_EQ(
-        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{1000}}
-             .get<Units::mm>()),
-        1);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{1.}}.get<Units::m>()), 1.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{1e-1}}.get<Units::dm>()),
+        1.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{1e-2}}.get<Units::cm>()),
+        1.);
+    EXPECT_DOUBLE_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{1e-3}}.get<Units::mm>()),
+        1.);
 }
 
 TEST(LengthUnit, makeLengthUnit)
@@ -76,48 +65,56 @@ TEST(LengthUnit, makeLengthUnit)
     using namespace jps;
     using namespace details;
     // Same unit
-    EXPECT_EQ((makeLengthUnit<Units::km>(10).get<Units::km>()), 10);
-    EXPECT_EQ((makeLengthUnit<Units::m>(10).get<Units::m>()), 10);
-    EXPECT_EQ((makeLengthUnit<Units::dm>(10).get<Units::dm>()), 10);
-    EXPECT_EQ((makeLengthUnit<Units::cm>(10).get<Units::cm>()), 10);
-    EXPECT_EQ((makeLengthUnit<Units::mm>(10).get<Units::mm>()), 10);
-    EXPECT_EQ((makeLengthUnit<Units::um>(10).get<Units::um>()), 10);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::km>(10.).get<Units::km>()), 10.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(10.).get<Units::m>()), 10.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::dm>(10.).get<Units::dm>()), 10.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::cm>(10.).get<Units::cm>()), 10.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::mm>(10.).get<Units::mm>()), 10.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::um>(10.).get<Units::um>()), 10.);
 
     // Check if scaling is used in constructor
-    EXPECT_EQ((makeLengthUnit<Units::km>(1).get<LengthUnit::RESOLUTION>()), 1000000000);
-    EXPECT_EQ((makeLengthUnit<Units::m>(1).get<LengthUnit::RESOLUTION>()), 1000000);
-    EXPECT_EQ((makeLengthUnit<Units::dm>(1).get<LengthUnit::RESOLUTION>()), 100000);
-    EXPECT_EQ((makeLengthUnit<Units::cm>(1).get<LengthUnit::RESOLUTION>()), 10000);
-    EXPECT_EQ((makeLengthUnit<Units::mm>(1).get<LengthUnit::RESOLUTION>()), 1000);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::km>(1.).get<LengthUnit::RESOLUTION>()), 1e3);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(1.).get<LengthUnit::RESOLUTION>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::dm>(1.).get<LengthUnit::RESOLUTION>()), 1e-1);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::cm>(1.).get<LengthUnit::RESOLUTION>()), 1e-2);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::mm>(1.).get<LengthUnit::RESOLUTION>()), 1e-3);
 
     // Check if scaling is used in get method
-    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1000000000).get<Units::km>()), 1);
-    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1000000).get<Units::m>()), 1);
-    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(100000).get<Units::dm>()), 1);
-    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(10000).get<Units::cm>()), 1);
-    EXPECT_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1000).get<Units::mm>()), 1);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1e3).get<Units::km>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1.).get<Units::m>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1e-1).get<Units::dm>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1e-2).get<Units::cm>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1e-3).get<Units::mm>()), 1.);
 }
 
 TEST(LengthUnit, UserDefinedLiterals)
 {
-    EXPECT_EQ((1_um).get<jps::Units::um>(), 1);
-    EXPECT_EQ((1_mm).get<jps::Units::mm>(), 1);
-    EXPECT_EQ((1_cm).get<jps::Units::cm>(), 1);
-    EXPECT_EQ((1_dm).get<jps::Units::dm>(), 1);
-    EXPECT_EQ((1_m).get<jps::Units::m>(), 1);
-    EXPECT_EQ((1_km).get<jps::Units::km>(), 1);
+    EXPECT_DOUBLE_EQ((1._um).get<jps::Units::um>(), 1.);
+    EXPECT_DOUBLE_EQ((1._mm).get<jps::Units::mm>(), 1.);
+    EXPECT_DOUBLE_EQ((1._cm).get<jps::Units::cm>(), 1.);
+    EXPECT_DOUBLE_EQ((1._dm).get<jps::Units::dm>(), 1.);
+    EXPECT_DOUBLE_EQ((1._m).get<jps::Units::m>(), 1.);
+    EXPECT_DOUBLE_EQ((1._km).get<jps::Units::km>(), 1.);
+
+    /// Test integral literals
+    EXPECT_DOUBLE_EQ((1_um).get<jps::Units::um>(), 1.);
+    EXPECT_DOUBLE_EQ((1_mm).get<jps::Units::mm>(), 1.);
+    EXPECT_DOUBLE_EQ((1_cm).get<jps::Units::cm>(), 1.);
+    EXPECT_DOUBLE_EQ((1_dm).get<jps::Units::dm>(), 1.);
+    EXPECT_DOUBLE_EQ((1_m).get<jps::Units::m>(), 1.);
+    EXPECT_DOUBLE_EQ((1_km).get<jps::Units::km>(), 1.);
 }
 
 TEST(LengthUnit, arithmetics)
 {
     using namespace jps;
 
-    auto lu       = makeLengthUnit<Units::mm>(1);
-    auto other_lu = makeLengthUnit<Units::um>(1);
+    auto lu       = makeLengthUnit<Units::mm>(1.);
+    auto other_lu = makeLengthUnit<Units::um>(1.);
 
     lu += other_lu;
-    EXPECT_EQ(lu.get(), 1001);
-    EXPECT_EQ(other_lu.get(), 1);
+    EXPECT_DOUBLE_EQ(lu.get<Units::um>(), 1001.);
+    EXPECT_DOUBLE_EQ(other_lu.get<Units::m>(), 1e-6);
 }
 
 

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -198,51 +198,6 @@ TEST(LengthUnit, scaleQuantity)
     using namespace jps;
     using namespace details;
 
-    // Integral type
-
-    // From km
-    EXPECT_EQ((scaleQuantity<Units::km, Units::um>(1)), 1000000000);
-    EXPECT_EQ((scaleQuantity<Units::km, Units::mm>(1)), 1000000);
-    EXPECT_EQ((scaleQuantity<Units::km, Units::cm>(1)), 100000);
-    EXPECT_EQ((scaleQuantity<Units::km, Units::dm>(1)), 10000);
-    EXPECT_EQ((scaleQuantity<Units::km, Units::m>(1)), 1000);
-
-    // From m
-    EXPECT_EQ((scaleQuantity<Units::m, Units::km>(1200)), 1);
-    EXPECT_EQ((scaleQuantity<Units::m, Units::dm>(2)), 20);
-    EXPECT_EQ((scaleQuantity<Units::m, Units::cm>(2)), 200);
-    EXPECT_EQ((scaleQuantity<Units::m, Units::mm>(2)), 2000);
-    EXPECT_EQ((scaleQuantity<Units::m, Units::um>(2)), 2000000);
-
-    // From dm
-    EXPECT_EQ((scaleQuantity<Units::dm, Units::km>(20000)), 2);
-    EXPECT_EQ((scaleQuantity<Units::dm, Units::m>(19)), 1);
-    EXPECT_EQ((scaleQuantity<Units::dm, Units::cm>(1)), 10);
-    EXPECT_EQ((scaleQuantity<Units::dm, Units::mm>(1)), 100);
-    EXPECT_EQ((scaleQuantity<Units::dm, Units::um>(1)), 100000);
-
-    // From cm
-    EXPECT_EQ((scaleQuantity<Units::cm, Units::km>(120000)), 1);
-    EXPECT_EQ((scaleQuantity<Units::cm, Units::m>(100)), 1);
-    EXPECT_EQ((scaleQuantity<Units::cm, Units::dm>(12)), 1);
-    EXPECT_EQ((scaleQuantity<Units::cm, Units::mm>(1)), 10);
-    EXPECT_EQ((scaleQuantity<Units::cm, Units::um>(2)), 20000);
-
-    // From mm
-    EXPECT_EQ((scaleQuantity<Units::mm, Units::km>(5000000)), 5);
-    EXPECT_EQ((scaleQuantity<Units::mm, Units::m>(1200)), 1);
-    EXPECT_EQ((scaleQuantity<Units::mm, Units::dm>(540)), 5);
-    EXPECT_EQ((scaleQuantity<Units::mm, Units::cm>(78)), 7);
-    EXPECT_EQ((scaleQuantity<Units::mm, Units::um>(5)), 5000);
-
-    // From um
-    EXPECT_EQ((scaleQuantity<Units::um, Units::km>(1234763874)), 1);
-    EXPECT_EQ((scaleQuantity<Units::um, Units::m>(1846574)), 1);
-    EXPECT_EQ((scaleQuantity<Units::um, Units::dm>(192837)), 1);
-    EXPECT_EQ((scaleQuantity<Units::um, Units::cm>(13823)), 1);
-    EXPECT_EQ((scaleQuantity<Units::um, Units::mm>(1234)), 1);
-
-
     // Floating points (double)
 
     // From km

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -126,6 +126,8 @@ TEST(LengthUnit, scaleQuantity)
     using namespace jps;
     using namespace details;
 
+    // Integral type
+
     // From km
     EXPECT_EQ((scaleQuantity<Units::km, Units::um>(1)), 1000000000);
     EXPECT_EQ((scaleQuantity<Units::km, Units::mm>(1)), 1000000);
@@ -167,4 +169,49 @@ TEST(LengthUnit, scaleQuantity)
     EXPECT_EQ((scaleQuantity<Units::um, Units::dm>(192837)), 1);
     EXPECT_EQ((scaleQuantity<Units::um, Units::cm>(13823)), 1);
     EXPECT_EQ((scaleQuantity<Units::um, Units::mm>(1234)), 1);
+
+
+    // Floating points (double)
+
+    // From km
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::km, Units::um>(1.)), 1000000000.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::km, Units::mm>(1.)), 1000000.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::km, Units::cm>(1.)), 100000.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::km, Units::dm>(1.)), 10000.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::km, Units::m>(1.)), 1000.);
+
+    // From m
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::m, Units::km>(1200.)), 1.2);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::m, Units::dm>(2.)), 20.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::m, Units::cm>(2.)), 200.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::m, Units::mm>(2.)), 2000.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::m, Units::um>(2.)), 2000000.);
+
+    // From dm
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::dm, Units::km>(20000.)), 2.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::dm, Units::m>(19.)), 1.9);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::dm, Units::cm>(1.)), 10.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::dm, Units::mm>(1.)), 100.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::dm, Units::um>(1.)), 100000.);
+
+    // From cm
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::cm, Units::km>(120000.)), 1.2);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::cm, Units::m>(100.)), 1.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::cm, Units::dm>(12.)), 1.2);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::cm, Units::mm>(1.)), 10.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::cm, Units::um>(2.)), 20000.);
+
+    // From mm
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::mm, Units::km>(5000000.)), 5.);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::mm, Units::m>(1200.)), 1.2);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::mm, Units::dm>(540.)), 5.4);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::mm, Units::cm>(78.)), 7.8);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::mm, Units::um>(5.)), 5000.);
+
+    // From um
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::um, Units::km>(1234763874.)), 1.234763874);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::um, Units::m>(1846574.)), 1.846574);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::um, Units::dm>(192837.)), 1.92837);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::um, Units::cm>(13823.)), 1.3823);
+    EXPECT_DOUBLE_EQ((scaleQuantity<Units::um, Units::mm>(1234.)), 1.234);
 }

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -2,6 +2,75 @@
 
 #include <gtest/gtest.h>
 
+TEST(LengthUnit, NonHelperConstruction)
+{
+    using namespace jps;
+    using namespace details;
+
+    // Same unit
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::km>{10}}.get<Units::km>()),
+        10);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{10}}.get<Units::m>()), 10);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::dm>{10}}.get<Units::dm>()),
+        10);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::cm>{10}}.get<Units::cm>()),
+        10);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mm>{10}}.get<Units::mm>()),
+        10);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mum>{10}}.get<Units::mum>()),
+        10);
+
+    // Check if scaling is used in constructor
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::km>{1}}
+             .get<LengthUnit::RESOLUTION>()),
+        1000000000);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::m>{1}}
+             .get<LengthUnit::RESOLUTION>()),
+        1000000);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::dm>{1}}
+             .get<LengthUnit::RESOLUTION>()),
+        100000);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::cm>{1}}
+             .get<LengthUnit::RESOLUTION>()),
+        10000);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, Units::mm>{1}}
+             .get<LengthUnit::RESOLUTION>()),
+        1000);
+
+    // Check if scaling is used in get method
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{1000000000}}
+             .get<Units::km>()),
+        1);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{1000000}}
+             .get<Units::m>()),
+        1);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{100000}}
+             .get<Units::dm>()),
+        1);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{10000}}
+             .get<Units::cm>()),
+        1);
+    EXPECT_EQ(
+        (LengthUnit{LengthUnitParams<LengthUnit::QuantityType, LengthUnit::RESOLUTION>{1000}}
+             .get<Units::mm>()),
+        1);
+}
+
 TEST(LengthUnit, scaleQuantity)
 {
     using namespace jps;

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -1,5 +1,6 @@
 #include "geometry/length_unit.hpp"
 
+#include <cmath>
 #include <gtest/gtest.h>
 
 TEST(LengthUnit, NonHelperConstruction)
@@ -96,7 +97,7 @@ TEST(LengthUnit, UserDefinedLiterals)
     EXPECT_DOUBLE_EQ((1._m).get<jps::Units::m>(), 1.);
     EXPECT_DOUBLE_EQ((1._km).get<jps::Units::km>(), 1.);
 
-    /// Test integral literals
+    // Test integral literals
     EXPECT_DOUBLE_EQ((1_um).get<jps::Units::um>(), 1.);
     EXPECT_DOUBLE_EQ((1_mm).get<jps::Units::mm>(), 1.);
     EXPECT_DOUBLE_EQ((1_cm).get<jps::Units::cm>(), 1.);
@@ -112,7 +113,7 @@ TEST(LengthUnit, arithmetics)
     auto lu       = makeLengthUnit<Units::mm>(1.);
     auto other_lu = makeLengthUnit<Units::um>(1.);
 
-    /// test +=
+    // test +=
     lu += other_lu;
     EXPECT_DOUBLE_EQ(lu.get<Units::um>(), 1001.);
     EXPECT_DOUBLE_EQ(other_lu.get<Units::m>(), 1e-6);
@@ -123,7 +124,7 @@ TEST(LengthUnit, arithmetics)
     lu       = 1_mm;
     other_lu = 1_mm;
 
-    /// Test symmetric + operator
+    // Test symmetric + operator
     auto result = lu + other_lu;
     EXPECT_DOUBLE_EQ(result.get<Units::mm>(), 2.);
     EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 1.);
@@ -134,7 +135,7 @@ TEST(LengthUnit, arithmetics)
     EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 1.);
     EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 1.);
 
-    /// negativ
+    // negativ
     result = -lu;
     EXPECT_DOUBLE_EQ(result.get<Units::mm>(), -1.);
     EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 1.);
@@ -142,7 +143,7 @@ TEST(LengthUnit, arithmetics)
     lu = -lu;
     EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), -1.);
 
-    /// operator -=
+    // operator -=
     lu       = 1_mm;
     other_lu = 1_mm;
 
@@ -153,7 +154,7 @@ TEST(LengthUnit, arithmetics)
     other_lu -= other_lu;
     EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 0.);
 
-    /// symmetric operator-
+    // symmetric operator-
     lu       = 10_mm;
     other_lu = 1_mm;
     result   = lu - other_lu;
@@ -167,6 +168,28 @@ TEST(LengthUnit, arithmetics)
     EXPECT_DOUBLE_EQ(result.get<Units::mm>(), -9.);
     EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 10.);
     EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 1.);
+
+    // division by scalar
+    lu     = 10_mm;
+    result = lu / 10;
+    EXPECT_DOUBLE_EQ(result.get<Units::mm>(), 1.);
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 10.);
+
+    result = lu / 0;
+    EXPECT_TRUE(std::isinf(result.get<Units::mm>()));
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 10.);
+
+    // multiplication with scalar
+    lu     = 10_mm;
+    result = lu * 5;
+    EXPECT_DOUBLE_EQ(result.get<Units::mm>(), 50.);
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 10.);
+
+    // symmetric multiplication operation
+    lu     = 10_mm;
+    result = 5 * lu;
+    EXPECT_DOUBLE_EQ(result.get<Units::mm>(), 50.);
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 10.);
 }
 
 

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -73,18 +73,18 @@ TEST(LengthUnit, makeLengthUnit)
     EXPECT_DOUBLE_EQ((makeLengthUnit<Units::um>(10.).get<Units::um>()), 10.);
 
     // Check if scaling is used in constructor
-    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::km>(1.).get<LengthUnit::RESOLUTION>()), 1e3);
-    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(1.).get<LengthUnit::RESOLUTION>()), 1.);
-    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::dm>(1.).get<LengthUnit::RESOLUTION>()), 1e-1);
-    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::cm>(1.).get<LengthUnit::RESOLUTION>()), 1e-2);
-    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::mm>(1.).get<LengthUnit::RESOLUTION>()), 1e-3);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::km>(1.).get<Units::m>()), 1e3);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(1.).get<Units::m>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::dm>(1.).get<Units::m>()), 1e-1);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::cm>(1.).get<Units::m>()), 1e-2);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::mm>(1.).get<Units::m>()), 1e-3);
 
     // Check if scaling is used in get method
-    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1e3).get<Units::km>()), 1.);
-    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1.).get<Units::m>()), 1.);
-    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1e-1).get<Units::dm>()), 1.);
-    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1e-2).get<Units::cm>()), 1.);
-    EXPECT_DOUBLE_EQ((makeLengthUnit<LengthUnit::RESOLUTION>(1e-3).get<Units::mm>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(1e3).get<Units::km>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(1.).get<Units::m>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(1e-1).get<Units::dm>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(1e-2).get<Units::cm>()), 1.);
+    EXPECT_DOUBLE_EQ((makeLengthUnit<Units::m>(1e-3).get<Units::mm>()), 1.);
 }
 
 TEST(LengthUnit, UserDefinedLiterals)

--- a/cpp/libcore/test/geometry/test_length_unit.cpp
+++ b/cpp/libcore/test/geometry/test_length_unit.cpp
@@ -112,9 +112,61 @@ TEST(LengthUnit, arithmetics)
     auto lu       = makeLengthUnit<Units::mm>(1.);
     auto other_lu = makeLengthUnit<Units::um>(1.);
 
+    /// test +=
     lu += other_lu;
     EXPECT_DOUBLE_EQ(lu.get<Units::um>(), 1001.);
     EXPECT_DOUBLE_EQ(other_lu.get<Units::m>(), 1e-6);
+
+    other_lu += other_lu;
+    EXPECT_DOUBLE_EQ(other_lu.get<Units::um>(), 2.);
+
+    lu       = 1_mm;
+    other_lu = 1_mm;
+
+    /// Test symmetric + operator
+    auto result = lu + other_lu;
+    EXPECT_DOUBLE_EQ(result.get<Units::mm>(), 2.);
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 1.);
+    EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 1.);
+
+    result = other_lu + lu;
+    EXPECT_DOUBLE_EQ(result.get<Units::mm>(), 2.);
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 1.);
+    EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 1.);
+
+    /// negativ
+    result = -lu;
+    EXPECT_DOUBLE_EQ(result.get<Units::mm>(), -1.);
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 1.);
+
+    lu = -lu;
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), -1.);
+
+    /// operator -=
+    lu       = 1_mm;
+    other_lu = 1_mm;
+
+    lu -= other_lu;
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 0.);
+    EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 1.);
+
+    other_lu -= other_lu;
+    EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 0.);
+
+    /// symmetric operator-
+    lu       = 10_mm;
+    other_lu = 1_mm;
+    result   = lu - other_lu;
+    EXPECT_DOUBLE_EQ(result.get<Units::mm>(), 9.);
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 10.);
+    EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 1.);
+
+    lu       = 10_mm;
+    other_lu = 1_mm;
+    result   = other_lu - lu;
+    EXPECT_DOUBLE_EQ(result.get<Units::mm>(), -9.);
+    EXPECT_DOUBLE_EQ(lu.get<Units::mm>(), 10.);
+    EXPECT_DOUBLE_EQ(other_lu.get<Units::mm>(), 1.);
 }
 
 

--- a/cpp/libcore/test/math/test_int_pow.cpp
+++ b/cpp/libcore/test/math/test_int_pow.cpp
@@ -5,9 +5,9 @@
 
 TEST(intPow, BasicTests)
 {
-    EXPECT_EQ((jps ::math::intPow<int, 10, 1>()), 10);
-    EXPECT_EQ((jps ::math::intPow<int, 10, 2>()), 100);
-    EXPECT_EQ((jps ::math::intPow<int, 2, 3>()), 8);
-    EXPECT_EQ((jps ::math::intPow<int, 0, 10>()), 0);
-    EXPECT_EQ((jps ::math::intPow<int, 100, 0>()), 1);
+    EXPECT_EQ((jps ::math::intPow<10, 1>()), 10);
+    EXPECT_EQ((jps ::math::intPow<10, 2>()), 100);
+    EXPECT_EQ((jps ::math::intPow<2, 3>()), 8);
+    EXPECT_EQ((jps ::math::intPow<0, 10>()), 0);
+    EXPECT_EQ((jps ::math::intPow<100, 0>()), 1);
 }

--- a/cpp/libcore/test/math/test_int_pow.cpp
+++ b/cpp/libcore/test/math/test_int_pow.cpp
@@ -1,0 +1,13 @@
+
+#include "math/int_pow.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(intPow, BasicTests)
+{
+    EXPECT_EQ((jps ::math::intPow<int, 10, 1>()), 10);
+    EXPECT_EQ((jps ::math::intPow<int, 10, 2>()), 100);
+    EXPECT_EQ((jps ::math::intPow<int, 2, 3>()), 8);
+    EXPECT_EQ((jps ::math::intPow<int, 0, 10>()), 0);
+    EXPECT_EQ((jps ::math::intPow<int, 100, 0>()), 1);
+}


### PR DESCRIPTION
`LengthUnit` provides a strong type for all length units.  It stores the actual unit using int64 in the defined `RESOLUTION` (currently micro meter). It automatically scales the unit to mum and to the desired unit in the `get` method. 
We store the quantity in a single resolution unit to avoid a lot of scaling for arithmetic operations. Additionally we decided that micro meter should be enough for all use cases in the simulator. 
Arithmetic operations are following.