### PR TITLE
pycore binding is split up into sub modules

### DIFF
--- a/cpp/pycore/source/CMakeLists.txt
+++ b/cpp/pycore/source/CMakeLists.txt
@@ -1,5 +1,14 @@
 pybind11_add_module(jpscore
-    simulator_binding.cpp
+    jpscore_binding.cpp
+
+    simulation_binding.hpp
+    simulation_binding.cpp
+
+    logging_binding.hpp
+    logging_binding.cpp
+
+    geometry/world_builder_binding.hpp
+    geometry/world_builder_binding.cpp
 )
 
 target_link_libraries(jpscore

--- a/cpp/pycore/source/geometry/world_builder_binding.cpp
+++ b/cpp/pycore/source/geometry/world_builder_binding.cpp
@@ -1,0 +1,4 @@
+#include "world_builder_binding.hpp"
+
+
+void bind_world_builder(pybind11::module_ & m) {}

--- a/cpp/pycore/source/geometry/world_builder_binding.hpp
+++ b/cpp/pycore/source/geometry/world_builder_binding.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+void bind_world_builder(pybind11::module_ & m);

--- a/cpp/pycore/source/jpscore_binding.cpp
+++ b/cpp/pycore/source/jpscore_binding.cpp
@@ -1,0 +1,20 @@
+#include "geometry/world_builder_binding.hpp"
+#include "logging_binding.hpp"
+#include "simulation_binding.hpp"
+
+#include <pybind11/pybind11.h>
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+PYBIND11_MODULE(jpscore, m)
+{
+    /// MODULE jpscore
+    bind_simulation(m);
+
+    /// SUB MODULE logging
+    auto m_logging = m.def_submodule("logging");
+    bind_logging(m_logging);
+
+    /// SUB MODULE geometry
+    auto m_geometry = m.def_submodule("geometry");
+    bind_world_builder(m_geometry);
+}

--- a/cpp/pycore/source/logging_binding.cpp
+++ b/cpp/pycore/source/logging_binding.cpp
@@ -1,43 +1,34 @@
+#include "logging_binding.hpp"
+
 #include <log.hpp>
 #include <pybind11/functional.h>
-#include <pybind11/pybind11.h>
-#include <simulation.hpp>
 
-namespace py = pybind11;
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-PYBIND11_MODULE(jpscore, m)
+void bind_logging(pybind11::module_ & m)
 {
-    py::class_<jps::Simulation>(m, "Simulation")
-        .def(py::init<>())
-        .def("get", &jps::Simulation::getValue);
-
-    auto m_logging = m.def_submodule("logging");
-
-    py::enum_<jps::Logging::Level>(m_logging, "Level")
+    pybind11::enum_<jps::Logging::Level>(m, "Level")
         .value("Debug", jps::Logging::Level::Debug)
         .value("Info", jps::Logging::Level::Info)
         .value("Warning", jps::Logging::Level::Warning)
         .value("Error", jps::Logging::Level::Error);
 
-    m_logging.def(
+    m.def(
         "set_callback",
         [](jps::Logging::Level level, jps::Logging::LogCallback callback) {
             jps::Logging::setCallback(
                 level, [callback = std::move(callback)](std::string_view msg) {
-                    py::gil_scoped_acquire lock;
+                    pybind11::gil_scoped_acquire lock;
                     callback(msg);
                 });
         },
-        py::kw_only(),
-        py::arg("level"),
-        py::arg("func"));
+        pybind11::kw_only(),
+        pybind11::arg("level"),
+        pybind11::arg("func"));
 
     /// Regsitered python functions are wrapped by pybind11. These wrappers have to be
     /// destructed before the interpreter is shutown. Since python does not destroy modules
     /// on shutdown registering an atexit handler is probably the most robust way to ensure
     /// destruction.
-    py::module_::import("atexit").attr("register")(py::cpp_function([]() {
+    pybind11::module_::import("atexit").attr("register")(pybind11::cpp_function([]() {
         jps::Logging::setCallback(jps::Logging::Level::Debug, jps::Logging::LogCallback{});
         jps::Logging::setCallback(jps::Logging::Level::Info, jps::Logging::LogCallback{});
         jps::Logging::setCallback(jps::Logging::Level::Warning, jps::Logging::LogCallback{});

--- a/cpp/pycore/source/logging_binding.hpp
+++ b/cpp/pycore/source/logging_binding.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+void bind_logging(pybind11::module_ & m);

--- a/cpp/pycore/source/simulation_binding.cpp
+++ b/cpp/pycore/source/simulation_binding.cpp
@@ -1,0 +1,10 @@
+#include "simulation_binding.hpp"
+
+#include <simulation.hpp>
+
+void bind_simulation(pybind11::module_ & m)
+{
+    pybind11::class_<jps::Simulation>(m, "Simulation")
+        .def(pybind11::init<>())
+        .def("get", &jps::Simulation::getValue);
+}

--- a/cpp/pycore/source/simulation_binding.hpp
+++ b/cpp/pycore/source/simulation_binding.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+void bind_simulation(pybind11::module_ & m);


### PR DESCRIPTION
We can not define all python bindings in a single cpp file. That is why
the binding is split up corresponding to the sub modules and the bound
libcore classes. Reference found here:
[https://pybind11.readthedocs.io/en/stable/faq.html#how-can-i-reduce-the-build-time](https://pybind11.readthedocs.io/en/stable/faq.html#how-can-i-reduce-the-build-time)
Nevertheless, structuring code was the reason, not build time.

@JetteSchumann I added the world builder binding as an empty function. 