### PR TITLE
Use trailing return types

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -5,7 +5,6 @@ Checks: >-
   cppcoreguidelines-*,
   misc-*,
   modernize-*,
-  -modernize-use-trailing-return-type,
   -modernize-use-nodiscard,
   performance-*,
   portability-*,

--- a/cpp/libcore/source/log.cpp
+++ b/cpp/libcore/source/log.cpp
@@ -16,7 +16,7 @@ private:
     std::array<Logging::LogCallback, 4> m_callbacks{};
 
 public:
-    static Log & instance()
+    static auto instance() -> Log &
     {
         static Log log{};
         return log;

--- a/cpp/libcore/source/simulation.hpp
+++ b/cpp/libcore/source/simulation.hpp
@@ -14,11 +14,11 @@ public:
     /// Non-copyable
     Simulation(const Simulation &) = delete;
     /// Non-copyable
-    Simulation & operator=(const Simulation &) = delete;
+    auto operator=(const Simulation &) -> Simulation & = delete;
     /// Non-movable
     Simulation(Simulation &&) = delete;
     /// Non-movable
-    Simulation & operator=(Simulation &&) = delete;
+    auto operator=(Simulation &&) -> Simulation & = delete;
     // NOLINTNEXTLINE
     int getValue() { return 1; }
 };

--- a/cpp/libcore/source/util/identifiable.hpp
+++ b/cpp/libcore/source/util/identifiable.hpp
@@ -21,17 +21,17 @@ public:
 
     /// Identified object should not be copied to avoid objects with same ID
     Identifiable(Identifiable const & /*p_other*/) = delete;
-    Identifiable & operator=(Identifiable const & /*p_other*/) = delete;
+    auto operator=(Identifiable const & /*p_other*/) -> Identifiable & = delete;
 
     /// For moved objects the same UID is used.
     Identifiable(Identifiable && p_other) noexcept : m_id{p_other.m_id} {};
-    Identifiable & operator=(Identifiable && p_other) noexcept
+    auto operator=(Identifiable && p_other) noexcept -> Identifiable &
     {
         m_id = p_other.m_id;
         return *this;
     }
 
 
-    unsigned int getID() const noexcept { return m_id; }
+    auto getID() const noexcept -> unsigned int { return m_id; }
 };
 } // namespace jps

--- a/cpp/libcore/test/.clang-tidy
+++ b/cpp/libcore/test/.clang-tidy
@@ -8,7 +8,6 @@ Checks: >-
   -cppcoreguidelines-avoid-non-const-global-variables,
   misc-*,
   modernize-*,
-  -modernize-use-trailing-return-type,
   -modernize-use-nodiscard,
   performance-*,
   portability-*,


### PR DESCRIPTION
After discussion yesterday, we agreed to use trailing return types in the cpp code base.

Following changes have been made:
- Use trailing return types (fixed with clang-tidy)
- Updated .clang-tidy to enable this check as default