### PR TITLE
Update clang-tidy files

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -8,7 +8,8 @@ Checks: >-
   -modernize-use-nodiscard,
   performance-*,
   portability-*,
-  readability-*
+  readability-*,
+  google-explicit-constructor
 WarningsAsErrors:    '*'
 HeaderFilterRegex:   '.*'
 FormatStyle:         file

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -42,7 +42,7 @@ template <typename QuantityType, Units Unit>
 struct LengthUnitParams {
     /// The quantity for the LengthUnit creation in Unit
     const QuantityType quantity; // NOLINT(misc-non-private-member-variables-in-classes)
-    LengthUnitParams(QuantityType p_quantity) : quantity{p_quantity} {}
+    explicit LengthUnitParams(QuantityType p_quantity) : quantity{p_quantity} {}
 };
 } // namespace details
 
@@ -80,7 +80,7 @@ public:
     ///
     /// @tparam Unit is the input unit of the quantity.
     template <Units Unit>
-    LengthUnit(details::LengthUnitParams<QuantityType, Unit> const & p_params) :
+    explicit LengthUnit(details::LengthUnitParams<QuantityType, Unit> const & p_params) :
         m_quantity{details::scaleQuantity<Unit, RESOLUTION>(p_params.quantity)}
     {
     }

--- a/cpp/libcore/test/.clang-tidy
+++ b/cpp/libcore/test/.clang-tidy
@@ -6,13 +6,17 @@ Checks: >-
   -cppcoreguidelines-special-member-functions,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-avoid-goto,
   misc-*,
   modernize-*,
   -modernize-use-nodiscard,
   performance-*,
+  -performance-move-const-arg,
+  -performance-unnecessary-copy-initialization,
   portability-*,
   readability-*,
   -readability-magic-numbers,
+  -readability-function-cognitive-complexity,
   -cppcoreguidelines-avoid-magic-numbers
 WarningsAsErrors:    '*'
 HeaderFilterRegex:   '.*'


### PR DESCRIPTION
After getting a lot of clang-tidy warnings/errors when writing the tests and a reviewer comment the clang-tidy files have been updated:

project:
- enforce explicit constructors

tests:
- ignore goto warning (`EXPECT_THROW` uses goto)
- ignore warnings about not needed moves/copies
- ignore high complexity test function warning