### PR TITLE
Adds destructor for Identifiable

### DIFF
--- a/cpp/libcore/source/util/identifiable.hpp
+++ b/cpp/libcore/source/util/identifiable.hpp
@@ -31,6 +31,7 @@ public:
         return *this;
     }
 
+    ~Identifiable() noexcept = default;
 
     auto getID() const noexcept -> unsigned int { return m_id; }
 };


### PR DESCRIPTION
When enabling the corresponding warning in the tests, they won't compile with: 
```
error: class 'Identifiable_Move_Test' defines a copy constructor and a copy assignment operator 
but does not define a destructor, a move constructor or a move assignment operator 
[cppcoreguidelines-special-member-functions,-warnings-as-errors]. 
```
This propagates towards every child class of `Identifiable` (see #43: `SpecialArea`). It seems not to be sufficient to define the destructor in the inheriting class. 