### PR TITLE
Length unit binding

### DIFF
--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -3,6 +3,7 @@
 #include "enum.hpp"
 #include "math/int_pow.hpp"
 
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <type_traits>
 
@@ -250,7 +251,7 @@ struct formatter<jps::LengthUnit> {
     template <typename FormatContext>
     auto format(jps::LengthUnit const & p_lu, FormatContext & p_ctx)
     {
-        return format_to(p_ctx.out(), "{:.4} m", p_lu.get<jps::Units::m>());
+        return format_to(p_ctx.out(), FMT_STRING("{:.4f} m"), p_lu.get<jps::Units::m>());
     }
 };
 } // namespace fmt

--- a/cpp/pycore/source/geometry/length_unit_binding.cpp
+++ b/cpp/pycore/source/geometry/length_unit_binding.cpp
@@ -2,6 +2,7 @@
 
 #include <geometry/length_unit.hpp>
 #include <pybind11/operators.h>
+#include <stdexcept>
 
 void bind_length_unit(pybind11::module_ & m)
 {
@@ -14,18 +15,54 @@ void bind_length_unit(pybind11::module_ & m)
         .value("km", jps::Units::km)
         .export_values();
 
-    pybind11::class_<jps::LengthUnit>(m, "LengthUnit")
-        .def(pybind11::init<>(&jps::makeLengthUnit<jps::Units::m>))
-        // NOLINTNEXTLINE(misc-redundant-expression)
-        .def(pybind11::detail::self == pybind11::detail::self)
-        // NOLINTNEXTLINE(misc-redundant-expression)
-        .def(pybind11::detail::self != pybind11::detail::self)
-        .def(
-            "__str__",
-            [](const jps::LengthUnit & length_unit) {
-                return fmt::format(FMT_STRING("{}"), length_unit);
-            })
-        .def("__repr__", [](const jps::LengthUnit & length_unit) {
-            return fmt::format(FMT_STRING("{}"), length_unit);
-        });
+    auto lu_binding = pybind11::class_<jps::LengthUnit>(m, "LengthUnit");
+    // Constructor switching the unit to the corresponding template parameter
+    lu_binding.def(pybind11::init([](jps::LengthUnit::QuantityType quantity, jps::Units unit) {
+        switch(unit) {
+            case jps::Units::um:
+                return jps::makeLengthUnit<jps::Units::um>(quantity);
+                break;
+            case jps::Units::mm:
+                return jps::makeLengthUnit<jps::Units::mm>(quantity);
+                break;
+            case jps::Units::cm:
+                return jps::makeLengthUnit<jps::Units::cm>(quantity);
+                break;
+            case jps::Units::dm:
+                return jps::makeLengthUnit<jps::Units::dm>(quantity);
+                break;
+            case jps::Units::m:
+                return jps::makeLengthUnit<jps::Units::m>(quantity);
+                break;
+            case jps::Units::km:
+                return jps::makeLengthUnit<jps::Units::km>(quantity);
+                break;
+            default:
+                throw std::runtime_error(fmt::format(
+                    FMT_STRING("Unit ({}) not yet implemented in python bindings."), unit));
+        }
+    }));
+    // Read only parameters for getting the length unit quantity in desired unit
+    lu_binding.def_property_readonly(
+        "um", &jps::LengthUnit::get<jps::Units::um>, "Retreive the quantity in micrometer");
+    lu_binding.def_property_readonly(
+        "mm", &jps::LengthUnit::get<jps::Units::mm>, "Retreive the quantity in millimeter");
+    lu_binding.def_property_readonly(
+        "cm", &jps::LengthUnit::get<jps::Units::cm>, "Retreive the quantity in centimeter");
+    lu_binding.def_property_readonly(
+        "dm", &jps::LengthUnit::get<jps::Units::dm>, "Retreive the quantity in decimeter");
+    lu_binding.def_property_readonly(
+        "m", &jps::LengthUnit::get<jps::Units::m>, "Retreive the quantity in meter");
+    lu_binding.def_property_readonly(
+        "km", &jps::LengthUnit::get<jps::Units::km>, "Retreive the quantity in kilometer");
+    // Comparison operators
+    lu_binding.def(pybind11::detail::self == pybind11::detail::self); // NOLINTLINE
+    lu_binding.def(pybind11::detail::self != pybind11::detail::self); // NOLINTLINE
+    // magic function for string
+    lu_binding.def("__str__", [](const jps::LengthUnit & length_unit) {
+        return fmt::format(FMT_STRING("{}"), length_unit);
+    });
+    lu_binding.def("__repr__", [](const jps::LengthUnit & length_unit) {
+        return fmt::format(FMT_STRING("{}"), length_unit);
+    });
 }

--- a/cpp/pycore/test/CMakeLists.txt
+++ b/cpp/pycore/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(python_tests
     geometry/line_segment_test.py
     geometry/spatial_vector_test.py
     geometry/special_area_test.py
+    geometry/length_unit_test.py
 )
 
 foreach(test ${python_tests})

--- a/cpp/pycore/test/geometry/area_test.py
+++ b/cpp/pycore/test/geometry/area_test.py
@@ -1,5 +1,12 @@
 import pytest
-from jpscore.geometry import Area, Coordinate, LengthUnit, Level, LineSegment
+from jpscore.geometry import (
+    Area,
+    Coordinate,
+    LengthUnit,
+    Level,
+    LineSegment,
+    Units,
+)
 
 
 class TestArea:
@@ -7,21 +14,73 @@ class TestArea:
         "coordinates",
         [
             [
-                Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
-                Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(3)),
-                Coordinate(LengthUnit(1.3), LengthUnit(-12.1), Level(3)),
-                Coordinate(LengthUnit(5.1), LengthUnit(-41.0), Level(3)),
-                Coordinate(LengthUnit(45.1), LengthUnit(-45.11), Level(3)),
-                Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(3)),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(0.65, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(0.45, Units.m),
+                    LengthUnit(61.1, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(1.3, Units.m),
+                    LengthUnit(-12.1, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(5.1, Units.m),
+                    LengthUnit(-41.0, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(45.1, Units.m),
+                    LengthUnit(-45.11, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(7.11, Units.m),
+                    LengthUnit(45.1, Units.m),
+                    Level(3),
+                ),
             ],
             [
-                Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
-                Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(3)),
-                Coordinate(LengthUnit(1.3), LengthUnit(-12.1), Level(3)),
-                Coordinate(LengthUnit(5.1), LengthUnit(-41.0), Level(3)),
-                Coordinate(LengthUnit(45.1), LengthUnit(-45.11), Level(3)),
-                Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(3)),
-                Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(0.65, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(0.45, Units.m),
+                    LengthUnit(61.1, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(1.3, Units.m),
+                    LengthUnit(-12.1, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(5.1, Units.m),
+                    LengthUnit(-41.0, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(45.1, Units.m),
+                    LengthUnit(-45.11, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(7.11, Units.m),
+                    LengthUnit(45.1, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(0.65, Units.m),
+                    Level(3),
+                ),
             ],
         ],
     )
@@ -39,14 +98,38 @@ class TestArea:
         [
             [],
             [
-                Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(4)),
-                Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(4)),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(0.65, Units.m),
+                    Level(4),
+                ),
+                Coordinate(
+                    LengthUnit(0.45, Units.m),
+                    LengthUnit(61.1, Units.m),
+                    Level(4),
+                ),
             ],
             [
-                Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
-                Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(5)),
-                Coordinate(LengthUnit(1.3), LengthUnit(-12.1), Level(3)),
-                Coordinate(LengthUnit(5.1), LengthUnit(-41.0), Level(3)),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(0.65, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(0.45, Units.m),
+                    LengthUnit(61.1, Units.m),
+                    Level(5),
+                ),
+                Coordinate(
+                    LengthUnit(1.3, Units.m),
+                    LengthUnit(-12.1, Units.m),
+                    Level(3),
+                ),
+                Coordinate(
+                    LengthUnit(5.1, Units.m),
+                    LengthUnit(-41.0, Units.m),
+                    Level(3),
+                ),
             ],
         ],
     )
@@ -59,60 +142,156 @@ class TestArea:
         [
             [
                 LineSegment(
-                    Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(3)),
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
+                    Coordinate(
+                        LengthUnit(7.11, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
-                    Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(3)),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.45, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(3)),
-                    Coordinate(LengthUnit(1.3), LengthUnit(-12.1), Level(3)),
+                    Coordinate(
+                        LengthUnit(0.45, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(1.3, Units.m),
+                        LengthUnit(-12.1, Units.m),
+                        Level(3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(1.3), LengthUnit(-12.1), Level(3)),
-                    Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(3)),
+                    Coordinate(
+                        LengthUnit(1.3, Units.m),
+                        LengthUnit(-12.1, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(7.11, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(3),
+                    ),
                 ),
             ],
             [
                 LineSegment(
-                    Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(3)),
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
+                    Coordinate(
+                        LengthUnit(7.11, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
-                    Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(3)),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.45, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(3)),
-                    Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(3)),
+                    Coordinate(
+                        LengthUnit(0.45, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(7.11, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(3),
+                    ),
                 ),
             ],
             [
                 LineSegment(
-                    Coordinate(LengthUnit(45.54), LengthUnit(45.1), Level(-3)),
-                    Coordinate(LengthUnit(1.41), LengthUnit(34.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(45.54, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(-3),
+                    ),
+                    Coordinate(
+                        LengthUnit(1.41, Units.m),
+                        LengthUnit(34.1, Units.m),
+                        Level(-3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(1.41), LengthUnit(34.1), Level(-3)),
-                    Coordinate(LengthUnit(-1.6), LengthUnit(12.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(1.41, Units.m),
+                        LengthUnit(34.1, Units.m),
+                        Level(-3),
+                    ),
+                    Coordinate(
+                        LengthUnit(-1.6, Units.m),
+                        LengthUnit(12.1, Units.m),
+                        Level(-3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(-1.6), LengthUnit(12.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(-1.6, Units.m),
+                        LengthUnit(12.1, Units.m),
+                        Level(-3),
+                    ),
                     Coordinate(LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)),
                 ),
                 LineSegment(
                     Coordinate(LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)),
-                    Coordinate(LengthUnit(-1.5), LengthUnit(34.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(-1.5, Units.m),
+                        LengthUnit(34.1, Units.m),
+                        Level(-3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(-1.5), LengthUnit(34.1), Level(-3)),
-                    Coordinate(LengthUnit(30.11), LengthUnit(15.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(-1.5, Units.m),
+                        LengthUnit(34.1, Units.m),
+                        Level(-3),
+                    ),
+                    Coordinate(
+                        LengthUnit(30.11, Units.m),
+                        LengthUnit(15.1, Units.m),
+                        Level(-3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(30.11), LengthUnit(15.1), Level(-3)),
-                    Coordinate(LengthUnit(45.54), LengthUnit(45.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(30.11, Units.m),
+                        LengthUnit(15.1, Units.m),
+                        Level(-3),
+                    ),
+                    Coordinate(
+                        LengthUnit(45.54, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(-3),
+                    ),
                 ),
             ],
         ],
@@ -132,12 +311,28 @@ class TestArea:
             [],
             [
                 LineSegment(
-                    Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(3)),
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
+                    Coordinate(
+                        LengthUnit(7.11, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
-                    Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(3)),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.45, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(3),
+                    ),
                 ),
             ],
         ],
@@ -153,50 +348,74 @@ class TestArea:
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(1.41), LengthUnit(34.1), Level(-3)
+                            LengthUnit(1.41, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-1.6), LengthUnit(12.1), Level(-3)
+                            LengthUnit(-1.6, Units.m),
+                            LengthUnit(12.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
                         ),
                         Coordinate(
-                            LengthUnit(-1.5), LengthUnit(34.1), Level(-3)
+                            LengthUnit(-1.5, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(30.11), LengthUnit(15.1), Level(-3)
+                            LengthUnit(30.11, Units.m),
+                            LengthUnit(15.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                     ]
                 ),
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(1.41), LengthUnit(34.1), Level(-3)
+                            LengthUnit(1.41, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-1.6), LengthUnit(12.1), Level(-3)
+                            LengthUnit(-1.6, Units.m),
+                            LengthUnit(12.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
                         ),
                         Coordinate(
-                            LengthUnit(-1.5), LengthUnit(34.1), Level(-3)
+                            LengthUnit(-1.5, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(30.11), LengthUnit(15.1), Level(-3)
+                            LengthUnit(30.11, Units.m),
+                            LengthUnit(15.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                     ]
                 ),
@@ -206,38 +425,58 @@ class TestArea:
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(0.1), LengthUnit(0.65), Level(3)
+                            LengthUnit(0.1, Units.m),
+                            LengthUnit(0.65, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(0.45), LengthUnit(61.1), Level(3)
+                            LengthUnit(0.45, Units.m),
+                            LengthUnit(61.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(1.3), LengthUnit(-12.1), Level(3)
+                            LengthUnit(1.3, Units.m),
+                            LengthUnit(-12.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                     ]
                 ),
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(0.1), LengthUnit(0.65), Level(3)
+                            LengthUnit(0.1, Units.m),
+                            LengthUnit(0.65, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(0.45), LengthUnit(61.1), Level(3)
+                            LengthUnit(0.45, Units.m),
+                            LengthUnit(61.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(1.3), LengthUnit(-12.1), Level(3)
+                            LengthUnit(1.3, Units.m),
+                            LengthUnit(-12.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                     ]
                 ),
@@ -247,44 +486,66 @@ class TestArea:
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(0.1), LengthUnit(0.65), Level(3)
+                            LengthUnit(0.1, Units.m),
+                            LengthUnit(0.65, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(0.45), LengthUnit(61.1), Level(3)
+                            LengthUnit(0.45, Units.m),
+                            LengthUnit(61.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(1.3), LengthUnit(-12.1), Level(3)
+                            LengthUnit(1.3, Units.m),
+                            LengthUnit(-12.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                     ]
                 ),
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(1.41), LengthUnit(34.1), Level(-3)
+                            LengthUnit(1.41, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-1.6), LengthUnit(12.1), Level(-3)
+                            LengthUnit(-1.6, Units.m),
+                            LengthUnit(12.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
                         ),
                         Coordinate(
-                            LengthUnit(-1.5), LengthUnit(34.1), Level(-3)
+                            LengthUnit(-1.5, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(30.11), LengthUnit(15.1), Level(-3)
+                            LengthUnit(30.11, Units.m),
+                            LengthUnit(15.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                     ]
                 ),
@@ -303,29 +564,51 @@ class TestArea:
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(1.41), LengthUnit(34.1), Level(-3)
+                            LengthUnit(1.41, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
                         ),
                         Coordinate(
-                            LengthUnit(-1.5), LengthUnit(34.1), Level(-3)
+                            LengthUnit(-1.5, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(30.11), LengthUnit(15.1), Level(-3)
+                            LengthUnit(30.11, Units.m),
+                            LengthUnit(15.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                     ]
                 ),
                 [
-                    Coordinate(LengthUnit(45.54), LengthUnit(45.1), Level(-3)),
-                    Coordinate(LengthUnit(1.41), LengthUnit(34.1), Level(-3)),
-                    Coordinate(LengthUnit(-1.6), LengthUnit(12.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(45.54, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(-3),
+                    ),
+                    Coordinate(
+                        LengthUnit(1.41, Units.m),
+                        LengthUnit(34.1, Units.m),
+                        Level(-3),
+                    ),
+                    Coordinate(
+                        LengthUnit(-1.6, Units.m),
+                        LengthUnit(12.1, Units.m),
+                        Level(-3),
+                    ),
                     Coordinate(LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)),
                 ],
             ),
@@ -333,24 +616,48 @@ class TestArea:
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(0.1), LengthUnit(0.65), Level(3)
+                            LengthUnit(0.1, Units.m),
+                            LengthUnit(0.65, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(1.3), LengthUnit(-12.1), Level(3)
+                            LengthUnit(1.3, Units.m),
+                            LengthUnit(-12.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                     ]
                 ),
                 [
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(3)),
-                    Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(3)),
-                    Coordinate(LengthUnit(1.3), LengthUnit(-12.1), Level(3)),
-                    Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(3)),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.45, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(1.3, Units.m),
+                        LengthUnit(-12.1, Units.m),
+                        Level(3),
+                    ),
+                    Coordinate(
+                        LengthUnit(7.11, Units.m),
+                        LengthUnit(45.1, Units.m),
+                        Level(3),
+                    ),
                 ],
             ),
         ],

--- a/cpp/pycore/test/geometry/area_test.py
+++ b/cpp/pycore/test/geometry/area_test.py
@@ -259,10 +259,18 @@ class TestArea:
                         LengthUnit(12.1, Units.m),
                         Level(-3),
                     ),
-                    Coordinate(LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(-6.1, Units.m),
+                        LengthUnit(-6.1, Units.m),
+                        Level(-3),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(-6.1, Units.m),
+                        LengthUnit(-6.1, Units.m),
+                        Level(-3),
+                    ),
                     Coordinate(
                         LengthUnit(-1.5, Units.m),
                         LengthUnit(34.1, Units.m),
@@ -363,7 +371,9 @@ class TestArea:
                             Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
+                            LengthUnit(-6.1, Units.m),
+                            LengthUnit(-6.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-1.5, Units.m),
@@ -400,7 +410,9 @@ class TestArea:
                             Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
+                            LengthUnit(-6.1, Units.m),
+                            LengthUnit(-6.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-1.5, Units.m),
@@ -530,7 +542,9 @@ class TestArea:
                             Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
+                            LengthUnit(-6.1, Units.m),
+                            LengthUnit(-6.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-1.5, Units.m),
@@ -574,7 +588,9 @@ class TestArea:
                             Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
+                            LengthUnit(-6.1, Units.m),
+                            LengthUnit(-6.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-1.5, Units.m),
@@ -609,7 +625,11 @@ class TestArea:
                         LengthUnit(12.1, Units.m),
                         Level(-3),
                     ),
-                    Coordinate(LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)),
+                    Coordinate(
+                        LengthUnit(-6.1, Units.m),
+                        LengthUnit(-6.1, Units.m),
+                        Level(-3),
+                    ),
                 ],
             ),
             (

--- a/cpp/pycore/test/geometry/coordinate_test.py
+++ b/cpp/pycore/test/geometry/coordinate_test.py
@@ -1,16 +1,28 @@
 import pytest
-from jpscore.geometry import Coordinate, LengthUnit, Level
+from jpscore.geometry import Coordinate, LengthUnit, Level, Units
 
 
 class TestCoordinate:
     @pytest.mark.parametrize(
         "x, y, lvl",
         [
-            (LengthUnit(-12.0), LengthUnit(435.1), Level(1)),
-            (LengthUnit(0.1), LengthUnit(0), Level(-12)),
-            (LengthUnit(95213), LengthUnit(-123.435), Level(435)),
-            (LengthUnit(94.45), LengthUnit(90941), Level(-912)),
-            (LengthUnit(-510.1), LengthUnit(32432.11), Level(63)),
+            (LengthUnit(-12.0, Units.m), LengthUnit(435.1, Units.m), Level(1)),
+            (LengthUnit(0.1, Units.m), LengthUnit(0, Units.m), Level(-12)),
+            (
+                LengthUnit(95213, Units.m),
+                LengthUnit(-123.435, Units.m),
+                Level(435),
+            ),
+            (
+                LengthUnit(94.45, Units.m),
+                LengthUnit(90941, Units.m),
+                Level(-912),
+            ),
+            (
+                LengthUnit(-510.1, Units.m),
+                LengthUnit(32432.11, Units.m),
+                Level(63),
+            ),
             (LengthUnit(-324), LengthUnit(-435.1), Level(0)),
         ],
     )
@@ -24,27 +36,43 @@ class TestCoordinate:
         "coordinate, new_x, new_y, new_lvl",
         [
             (
-                Coordinate(LengthUnit(-10.12), LengthUnit(34.12), Level(5)),
+                Coordinate(
+                    LengthUnit(-10.12, Units.m),
+                    LengthUnit(34.12, Units.m),
+                    Level(5),
+                ),
                 LengthUnit(-12.45),
-                LengthUnit(657),
+                LengthUnit(657, Units.m),
                 Level(5),
             ),
             (
-                Coordinate(LengthUnit(56.42), LengthUnit(-1.435), Level(14)),
-                LengthUnit(12.4),
-                LengthUnit(34.1),
+                Coordinate(
+                    LengthUnit(56.42, Units.m),
+                    LengthUnit(-1.435, Units.m),
+                    Level(14),
+                ),
+                LengthUnit(12.4, Units.m),
+                LengthUnit(34.1, Units.m),
                 Level(546),
             ),
             (
-                Coordinate(LengthUnit(0.11), LengthUnit(-1.11111), Level(-1)),
-                LengthUnit(0),
-                LengthUnit(0.00),
+                Coordinate(
+                    LengthUnit(0.11, Units.m),
+                    LengthUnit(-1.11111, Units.m),
+                    Level(-1),
+                ),
+                LengthUnit(0, Units.m),
+                LengthUnit(0.00, Units.m),
                 Level(56),
             ),
             (
-                Coordinate(LengthUnit(55.1), LengthUnit(5), Level(-2)),
+                Coordinate(
+                    LengthUnit(55.1, Units.m),
+                    LengthUnit(5, Units.m),
+                    Level(-2),
+                ),
                 LengthUnit(-1.1234),
-                LengthUnit(12),
+                LengthUnit(12, Units.m),
                 Level(12),
             ),
         ],
@@ -63,61 +91,133 @@ class TestCoordinate:
         "coordinate, other, result",
         [
             (
-                Coordinate(LengthUnit(-10.12), LengthUnit(34.12), Level(5)),
-                Coordinate(LengthUnit(-10.12), LengthUnit(34.12), Level(5)),
-                True,
-            ),
-            (
-                Coordinate(LengthUnit(-10.1254), LengthUnit(6.12), Level(-15)),
-                Coordinate(LengthUnit(-10.1254), LengthUnit(6.12), Level(-15)),
-                True,
-            ),
-            (
-                Coordinate(LengthUnit(3.56), LengthUnit(-12.67), Level(1)),
-                Coordinate(LengthUnit(3.56), LengthUnit(-12.67), Level(1)),
-                True,
-            ),
-            (
-                Coordinate(LengthUnit(-78.34), LengthUnit(65.712), Level(-27)),
-                Coordinate(LengthUnit(-78.34), LengthUnit(65.712), Level(-27)),
-                True,
-            ),
-            (
                 Coordinate(
-                    LengthUnit(0.0000001), LengthUnit(851.1), Level(912)
+                    LengthUnit(-10.12, Units.m),
+                    LengthUnit(34.12, Units.m),
+                    Level(5),
                 ),
                 Coordinate(
-                    LengthUnit(0.0000001), LengthUnit(851.1), Level(912)
+                    LengthUnit(-10.12, Units.m),
+                    LengthUnit(34.12, Units.m),
+                    Level(5),
                 ),
                 True,
             ),
             (
-                Coordinate(LengthUnit(3.56), LengthUnit(-12.67), Level(1)),
                 Coordinate(
-                    LengthUnit(0.0000001), LengthUnit(851.1), Level(912)
+                    LengthUnit(-10.1254, Units.m),
+                    LengthUnit(6.12, Units.m),
+                    Level(-15),
+                ),
+                Coordinate(
+                    LengthUnit(-10.1254, Units.m),
+                    LengthUnit(6.12, Units.m),
+                    Level(-15),
+                ),
+                True,
+            ),
+            (
+                Coordinate(
+                    LengthUnit(3.56, Units.m),
+                    LengthUnit(-12.67, Units.m),
+                    Level(1),
+                ),
+                Coordinate(
+                    LengthUnit(3.56, Units.m),
+                    LengthUnit(-12.67, Units.m),
+                    Level(1),
+                ),
+                True,
+            ),
+            (
+                Coordinate(
+                    LengthUnit(-78.34, Units.m),
+                    LengthUnit(65.712, Units.m),
+                    Level(-27),
+                ),
+                Coordinate(
+                    LengthUnit(-78.34, Units.m),
+                    LengthUnit(65.712, Units.m),
+                    Level(-27),
+                ),
+                True,
+            ),
+            (
+                Coordinate(
+                    LengthUnit(0.0000001, Units.m),
+                    LengthUnit(851.1, Units.m),
+                    Level(912),
+                ),
+                Coordinate(
+                    LengthUnit(0.0000001, Units.m),
+                    LengthUnit(851.1, Units.m),
+                    Level(912),
+                ),
+                True,
+            ),
+            (
+                Coordinate(
+                    LengthUnit(3.56, Units.m),
+                    LengthUnit(-12.67, Units.m),
+                    Level(1),
+                ),
+                Coordinate(
+                    LengthUnit(0.0000001, Units.m),
+                    LengthUnit(851.1, Units.m),
+                    Level(912),
                 ),
                 False,
             ),
             (
-                Coordinate(LengthUnit(3.56), LengthUnit(-12.67), Level(1)),
-                Coordinate(LengthUnit(-78.34), LengthUnit(65.712), Level(-27)),
-                False,
-            ),
-            (
-                Coordinate(LengthUnit(-78.34), LengthUnit(65.712), Level(-27)),
-                Coordinate(LengthUnit(-10.12), LengthUnit(34.12), Level(5)),
+                Coordinate(
+                    LengthUnit(3.56, Units.m),
+                    LengthUnit(-12.67, Units.m),
+                    Level(1),
+                ),
+                Coordinate(
+                    LengthUnit(-78.34, Units.m),
+                    LengthUnit(65.712, Units.m),
+                    Level(-27),
+                ),
                 False,
             ),
             (
                 Coordinate(
-                    LengthUnit(0.0000001), LengthUnit(851.1), Level(912)
+                    LengthUnit(-78.34, Units.m),
+                    LengthUnit(65.712, Units.m),
+                    Level(-27),
                 ),
-                Coordinate(LengthUnit(-10.1254), LengthUnit(6.12), Level(-15)),
+                Coordinate(
+                    LengthUnit(-10.12, Units.m),
+                    LengthUnit(34.12, Units.m),
+                    Level(5),
+                ),
                 False,
             ),
             (
-                Coordinate(LengthUnit(-10.1254), LengthUnit(6.12), Level(-15)),
-                Coordinate(LengthUnit(3.56), LengthUnit(-12.67), Level(1)),
+                Coordinate(
+                    LengthUnit(0.0000001, Units.m),
+                    LengthUnit(851.1, Units.m),
+                    Level(912),
+                ),
+                Coordinate(
+                    LengthUnit(-10.1254, Units.m),
+                    LengthUnit(6.12, Units.m),
+                    Level(-15),
+                ),
+                False,
+            ),
+            (
+                Coordinate(
+                    LengthUnit(-10.1254, Units.m),
+                    LengthUnit(6.12, Units.m),
+                    Level(-15),
+                ),
+                Coordinate(
+                    LengthUnit(3.56, Units.m),
+                    LengthUnit(-12.67, Units.m),
+                    Level(1),
+                ),
                 False,
             ),
         ],

--- a/cpp/pycore/test/geometry/coordinate_test.py
+++ b/cpp/pycore/test/geometry/coordinate_test.py
@@ -23,7 +23,7 @@ class TestCoordinate:
                 LengthUnit(32432.11, Units.m),
                 Level(63),
             ),
-            (LengthUnit(-324), LengthUnit(-435.1), Level(0)),
+            (LengthUnit(-324, Units.m), LengthUnit(-435.1, Units.m), Level(0)),
         ],
     )
     def test_constructor(self, x, y, lvl):
@@ -41,7 +41,7 @@ class TestCoordinate:
                     LengthUnit(34.12, Units.m),
                     Level(5),
                 ),
-                LengthUnit(-12.45),
+                LengthUnit(-12.45, Units.m),
                 LengthUnit(657, Units.m),
                 Level(5),
             ),
@@ -71,7 +71,7 @@ class TestCoordinate:
                     LengthUnit(5, Units.m),
                     Level(-2),
                 ),
-                LengthUnit(-1.1234),
+                LengthUnit(-1.1234, Units.m),
                 LengthUnit(12, Units.m),
                 Level(12),
             ),

--- a/cpp/pycore/test/geometry/length_unit_test.py
+++ b/cpp/pycore/test/geometry/length_unit_test.py
@@ -1,0 +1,97 @@
+import pytest
+from jpscore.geometry import LengthUnit, Units
+
+
+class TestUnits:
+    @pytest.mark.parametrize(
+        "unit",
+        ["um", "mm", "cm", "dm", "m", "km"],
+    )
+    def test_unit_exists(self, unit):
+        assert Units.__members__[unit]
+
+    @pytest.mark.parametrize(
+        "unit",
+        ["mmm", "KM", "Um", "M", "uM"],
+    )
+    def test_unit_not_exists(self, unit):
+        with pytest.raises(KeyError):
+            Units.__members__[unit]
+
+
+class TestLengthUnit:
+    @pytest.mark.parametrize(
+        "unit, quantity",
+        [
+            (Units.um, 5),
+            (Units.mm, 5),
+            (Units.cm, 5),
+            (Units.dm, 5),
+            (Units.m, 5),
+            (Units.km, 5),
+            (Units.um, 1.2),
+            (Units.mm, 3.4),
+            (Units.cm, 0.000012),
+            (Units.dm, 123123.09),
+            (Units.m, 1.1),
+            (Units.km, 512),
+            (Units.um, -100),
+            (Units.mm, -3.2),
+            (Units.cm, -5.2),
+            (Units.dm, -0.00001),
+            (Units.m, -10),
+            (Units.km, -1),
+        ],
+    )
+    def test_length_unit_ctor(self, unit, quantity):
+        assert type(LengthUnit(quantity, unit)) is LengthUnit
+
+    @pytest.mark.parametrize(
+        "lu",
+        [LengthUnit(1, Units.m), LengthUnit(1.001, Units.m)],
+    )
+    def test_lu_getter(self, lu):
+        assert type(lu.um) is float
+        assert type(lu.mm) is float
+        assert type(lu.cm) is float
+        assert type(lu.dm) is float
+        assert type(lu.m) is float
+        assert type(lu.km) is float
+
+    @pytest.mark.parametrize(
+        "lu, other",
+        [
+            (LengthUnit(1, Units.m), LengthUnit(1, Units.m)),
+            (LengthUnit(2.1, Units.m), LengthUnit(2.1, Units.m)),
+            (LengthUnit(2.0, Units.mm), LengthUnit(2000.0, Units.um)),
+            (LengthUnit(2, Units.m), LengthUnit(2.0, Units.m)),
+        ],
+    )
+    def test_lu_eq_operators_positiv(self, lu, other):
+        assert lu == other
+        assert not (lu != other)
+
+    @pytest.mark.parametrize(
+        "lu, other",
+        [
+            (LengthUnit(2, Units.m), LengthUnit(1, Units.m)),
+            (LengthUnit(2.1, Units.mm), LengthUnit(2.1, Units.m)),
+            (LengthUnit(20.0, Units.mm), LengthUnit(2000.0, Units.um)),
+            (LengthUnit(2, Units.km), LengthUnit(2.0, Units.m)),
+        ],
+    )
+    def test_lu_eq_operators_negativ(self, lu, other):
+        assert not (lu == other)
+        assert lu != other
+
+    @pytest.mark.parametrize(
+        "lu, expected_str, expected_repr",
+        [
+            (LengthUnit(2, Units.m), "2.0000 m", "2.0000 m"),
+            (LengthUnit(2, Units.mm), "0.0020 m", "0.0020 m"),
+            (LengthUnit(2, Units.um), "0.0000 m", "0.0000 m"),
+        ],
+    )
+    def test_lu_str_repr(self, lu, expected_str, expected_repr):
+        assert str(lu) == expected_str
+        assert repr(lu) == expected_repr

--- a/cpp/pycore/test/geometry/line_segment_test.py
+++ b/cpp/pycore/test/geometry/line_segment_test.py
@@ -1,5 +1,5 @@
 import pytest
-from jpscore.geometry import Coordinate, LengthUnit, Level, LineSegment
+from jpscore.geometry import Coordinate, LengthUnit, Level, LineSegment, Units
 
 
 class TestLineSegment:
@@ -7,20 +7,52 @@ class TestLineSegment:
         "start, end",
         [
             (
-                Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(4)),
-                Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(4)),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(0.65, Units.m),
+                    Level(4),
+                ),
+                Coordinate(
+                    LengthUnit(0.45, Units.m),
+                    LengthUnit(61.1, Units.m),
+                    Level(4),
+                ),
             ),
             (
-                Coordinate(LengthUnit(1.3), LengthUnit(-12.1), Level(54)),
-                Coordinate(LengthUnit(5.1), LengthUnit(-41.0), Level(54)),
+                Coordinate(
+                    LengthUnit(1.3, Units.m),
+                    LengthUnit(-12.1, Units.m),
+                    Level(54),
+                ),
+                Coordinate(
+                    LengthUnit(5.1, Units.m),
+                    LengthUnit(-41.0, Units.m),
+                    Level(54),
+                ),
             ),
             (
-                Coordinate(LengthUnit(45.1), LengthUnit(-45.11), Level(-1)),
-                Coordinate(LengthUnit(7.11), LengthUnit(45.1), Level(-1)),
+                Coordinate(
+                    LengthUnit(45.1, Units.m),
+                    LengthUnit(-45.11, Units.m),
+                    Level(-1),
+                ),
+                Coordinate(
+                    LengthUnit(7.11, Units.m),
+                    LengthUnit(45.1, Units.m),
+                    Level(-1),
+                ),
             ),
             (
-                Coordinate(LengthUnit(-56.61), LengthUnit(1.34), Level(0)),
-                Coordinate(LengthUnit(-4.11), LengthUnit(7.0001), Level(0)),
+                Coordinate(
+                    LengthUnit(-56.61, Units.m),
+                    LengthUnit(1.34, Units.m),
+                    Level(0),
+                ),
+                Coordinate(
+                    LengthUnit(-4.11, Units.m),
+                    LengthUnit(7.0001, Units.m),
+                    Level(0),
+                ),
             ),
             (
                 Coordinate(
@@ -39,12 +71,28 @@ class TestLineSegment:
         "start, end",
         [
             (
-                Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(4)),
-                Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(1)),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(0.65, Units.m),
+                    Level(4),
+                ),
+                Coordinate(
+                    LengthUnit(0.45, Units.m),
+                    LengthUnit(61.1, Units.m),
+                    Level(1),
+                ),
             ),
             (
-                Coordinate(LengthUnit(1.1), LengthUnit(-0.1), Level(0)),
-                Coordinate(LengthUnit(1.1), LengthUnit(-0.1), Level(0)),
+                Coordinate(
+                    LengthUnit(1.1, Units.m),
+                    LengthUnit(-0.1, Units.m),
+                    Level(0),
+                ),
+                Coordinate(
+                    LengthUnit(1.1, Units.m),
+                    LengthUnit(-0.1, Units.m),
+                    Level(0),
+                ),
             ),
         ],
     )
@@ -56,20 +104,44 @@ class TestLineSegment:
         "line_segment",
         [
             LineSegment(
-                Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(4)),
-                Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(4)),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(0.65, Units.m),
+                    Level(4),
+                ),
+                Coordinate(
+                    LengthUnit(0.45, Units.m),
+                    LengthUnit(61.1, Units.m),
+                    Level(4),
+                ),
             ),
             LineSegment(
-                Coordinate(LengthUnit(36.1), LengthUnit(45.1), Level(1)),
-                Coordinate(LengthUnit(67.1), LengthUnit(56.1), Level(1)),
+                Coordinate(
+                    LengthUnit(36.1, Units.m),
+                    LengthUnit(45.1, Units.m),
+                    Level(1),
+                ),
+                Coordinate(
+                    LengthUnit(67.1, Units.m),
+                    LengthUnit(56.1, Units.m),
+                    Level(1),
+                ),
             ),
             LineSegment(
                 Coordinate(LengthUnit(-32.54), LengthUnit(-61.11), Level(-4)),
                 Coordinate(LengthUnit(-12.6), LengthUnit(-718.3), Level(-4)),
             ),
             LineSegment(
-                Coordinate(LengthUnit(0.1), LengthUnit(-56.1), Level(0)),
-                Coordinate(LengthUnit(-56.1), LengthUnit(0.1), Level(0)),
+                Coordinate(
+                    LengthUnit(0.1, Units.m),
+                    LengthUnit(-56.1, Units.m),
+                    Level(0),
+                ),
+                Coordinate(
+                    LengthUnit(-56.1, Units.m),
+                    LengthUnit(0.1, Units.m),
+                    Level(0),
+                ),
             ),
         ],
     )
@@ -87,56 +159,136 @@ class TestLineSegment:
         [
             (
                 LineSegment(
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(4)),
-                    Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(4)),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(4),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.45, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(4),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(4)),
-                    Coordinate(LengthUnit(0.45), LengthUnit(61.1), Level(4)),
-                ),
-                True,
-            ),
-            (
-                LineSegment(
-                    Coordinate(LengthUnit(4.145), LengthUnit(-3.1), Level(-2)),
-                    Coordinate(LengthUnit(90.1), LengthUnit(0.11), Level(-2)),
-                ),
-                LineSegment(
-                    Coordinate(LengthUnit(90.1), LengthUnit(0.11), Level(-2)),
-                    Coordinate(LengthUnit(4.145), LengthUnit(-3.1), Level(-2)),
-                ),
-                True,
-            ),
-            (
-                LineSegment(
-                    Coordinate(LengthUnit(-32.5), LengthUnit(0.11), Level(20)),
-                    Coordinate(LengthUnit(-41.1), LengthUnit(0.11), Level(20)),
-                ),
-                LineSegment(
-                    Coordinate(LengthUnit(-32.5), LengthUnit(0.11), Level(20)),
-                    Coordinate(LengthUnit(-41.1), LengthUnit(0.11), Level(20)),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(4),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.45, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(4),
+                    ),
                 ),
                 True,
             ),
             (
                 LineSegment(
-                    Coordinate(LengthUnit(34.5), LengthUnit(56.81), Level(1)),
-                    Coordinate(LengthUnit(0.41), LengthUnit(90.1), Level(1)),
+                    Coordinate(
+                        LengthUnit(4.145, Units.m),
+                        LengthUnit(-3.1, Units.m),
+                        Level(-2),
+                    ),
+                    Coordinate(
+                        LengthUnit(90.1, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(-2),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(0.001), LengthUnit(3.1), Level(1)),
-                    Coordinate(LengthUnit(-41.1), LengthUnit(8.11), Level(1)),
+                    Coordinate(
+                        LengthUnit(90.1, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(-2),
+                    ),
+                    Coordinate(
+                        LengthUnit(4.145, Units.m),
+                        LengthUnit(-3.1, Units.m),
+                        Level(-2),
+                    ),
+                ),
+                True,
+            ),
+            (
+                LineSegment(
+                    Coordinate(
+                        LengthUnit(-32.5, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(20),
+                    ),
+                    Coordinate(
+                        LengthUnit(-41.1, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(20),
+                    ),
+                ),
+                LineSegment(
+                    Coordinate(
+                        LengthUnit(-32.5, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(20),
+                    ),
+                    Coordinate(
+                        LengthUnit(-41.1, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(20),
+                    ),
+                ),
+                True,
+            ),
+            (
+                LineSegment(
+                    Coordinate(
+                        LengthUnit(34.5, Units.m),
+                        LengthUnit(56.81, Units.m),
+                        Level(1),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.41, Units.m),
+                        LengthUnit(90.1, Units.m),
+                        Level(1),
+                    ),
+                ),
+                LineSegment(
+                    Coordinate(
+                        LengthUnit(0.001, Units.m),
+                        LengthUnit(3.1, Units.m),
+                        Level(1),
+                    ),
+                    Coordinate(
+                        LengthUnit(-41.1, Units.m),
+                        LengthUnit(8.11, Units.m),
+                        Level(1),
+                    ),
                 ),
                 False,
             ),
             (
                 LineSegment(
-                    Coordinate(LengthUnit(-32.5), LengthUnit(0.11), Level(20)),
-                    Coordinate(LengthUnit(-41.1), LengthUnit(0.11), Level(20)),
+                    Coordinate(
+                        LengthUnit(-32.5, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(20),
+                    ),
+                    Coordinate(
+                        LengthUnit(-41.1, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(20),
+                    ),
                 ),
                 LineSegment(
-                    Coordinate(LengthUnit(-32.5), LengthUnit(0.11), Level(1)),
-                    Coordinate(LengthUnit(-41.1), LengthUnit(0.11), Level(1)),
+                    Coordinate(
+                        LengthUnit(-32.5, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(1),
+                    ),
+                    Coordinate(
+                        LengthUnit(-41.1, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(1),
+                    ),
                 ),
                 False,
             ),
@@ -151,19 +303,51 @@ class TestLineSegment:
         [
             (
                 LineSegment(
-                    Coordinate(LengthUnit(-32.5), LengthUnit(0.11), Level(20)),
-                    Coordinate(LengthUnit(-41.1), LengthUnit(0.11), Level(20)),
+                    Coordinate(
+                        LengthUnit(-32.5, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(20),
+                    ),
+                    Coordinate(
+                        LengthUnit(-41.1, Units.m),
+                        LengthUnit(0.11, Units.m),
+                        Level(20),
+                    ),
                 ),
-                Coordinate(LengthUnit(45.1), LengthUnit(1.1), Level(20)),
-                Coordinate(LengthUnit(-41.1), LengthUnit(45.1), Level(20)),
+                Coordinate(
+                    LengthUnit(45.1, Units.m),
+                    LengthUnit(1.1, Units.m),
+                    Level(20),
+                ),
+                Coordinate(
+                    LengthUnit(-41.1, Units.m),
+                    LengthUnit(45.1, Units.m),
+                    Level(20),
+                ),
             ),
             (
                 LineSegment(
-                    Coordinate(LengthUnit(0.1), LengthUnit(0.65), Level(4)),
-                    Coordinate(LengthUnit(0.12), LengthUnit(61.1), Level(4)),
+                    Coordinate(
+                        LengthUnit(0.1, Units.m),
+                        LengthUnit(0.65, Units.m),
+                        Level(4),
+                    ),
+                    Coordinate(
+                        LengthUnit(0.12, Units.m),
+                        LengthUnit(61.1, Units.m),
+                        Level(4),
+                    ),
                 ),
-                Coordinate(LengthUnit(234.1), LengthUnit(0.11), Level(20)),
-                Coordinate(LengthUnit(-41.1), LengthUnit(0.11), Level(20)),
+                Coordinate(
+                    LengthUnit(234.1, Units.m),
+                    LengthUnit(0.11, Units.m),
+                    Level(20),
+                ),
+                Coordinate(
+                    LengthUnit(-41.1, Units.m),
+                    LengthUnit(0.11, Units.m),
+                    Level(20),
+                ),
             ),
         ],
     )

--- a/cpp/pycore/test/geometry/line_segment_test.py
+++ b/cpp/pycore/test/geometry/line_segment_test.py
@@ -56,9 +56,15 @@ class TestLineSegment:
             ),
             (
                 Coordinate(
-                    LengthUnit(-41.1111), LengthUnit(-324.11), Level(-4)
+                    LengthUnit(-41.1111, Units.m),
+                    LengthUnit(-324.11, Units.m),
+                    Level(-4),
                 ),
-                Coordinate(LengthUnit(-41.0), LengthUnit(-320.11), Level(-4)),
+                Coordinate(
+                    LengthUnit(-41.0, Units.m),
+                    LengthUnit(-320.11, Units.m),
+                    Level(-4),
+                ),
             ),
         ],
     )
@@ -128,8 +134,16 @@ class TestLineSegment:
                 ),
             ),
             LineSegment(
-                Coordinate(LengthUnit(-32.54), LengthUnit(-61.11), Level(-4)),
-                Coordinate(LengthUnit(-12.6), LengthUnit(-718.3), Level(-4)),
+                Coordinate(
+                    LengthUnit(-32.54, Units.m),
+                    LengthUnit(-61.11, Units.m),
+                    Level(-4),
+                ),
+                Coordinate(
+                    LengthUnit(-12.6, Units.m),
+                    LengthUnit(-718.3, Units.m),
+                    Level(-4),
+                ),
             ),
             LineSegment(
                 Coordinate(

--- a/cpp/pycore/test/geometry/spatial_vector_test.py
+++ b/cpp/pycore/test/geometry/spatial_vector_test.py
@@ -1,16 +1,16 @@
 import pytest
-from jpscore.geometry import LengthUnit, SpatialVector
+from jpscore.geometry import LengthUnit, SpatialVector, Units
 
 
 class TestSpatialVector:
     @pytest.mark.parametrize(
         "x, y",
         [
-            (LengthUnit(-12.0), LengthUnit(435.1)),
-            (LengthUnit(12.0), LengthUnit(-71.5)),
+            (LengthUnit(-12.0, Units.m), LengthUnit(435.1, Units.m)),
+            (LengthUnit(12.0, Units.m), LengthUnit(-71.5, Units.m)),
             (LengthUnit(-1.010101), LengthUnit(-0.0)),
-            (LengthUnit(561.5), LengthUnit(46.11)),
-            (LengthUnit(-0.01), LengthUnit(73.12)),
+            (LengthUnit(561.5, Units.m), LengthUnit(46.11, Units.m)),
+            (LengthUnit(-0.01, Units.m), LengthUnit(73.12, Units.m)),
         ],
     )
     def test_constructor(self, x, y):
@@ -22,28 +22,36 @@ class TestSpatialVector:
         "spatial_vector, new_x, new_y",
         [
             (
-                SpatialVector(LengthUnit(-10.12), LengthUnit(34.12)),
+                SpatialVector(
+                    LengthUnit(-10.12, Units.m), LengthUnit(34.12, Units.m)
+                ),
                 LengthUnit(-12.45),
-                LengthUnit(657),
+                LengthUnit(657, Units.m),
             ),
             (
-                SpatialVector(LengthUnit(345.0), LengthUnit(-61.1)),
-                LengthUnit(9.8),
-                LengthUnit(0.1),
+                SpatialVector(
+                    LengthUnit(345.0, Units.m), LengthUnit(-61.1, Units.m)
+                ),
+                LengthUnit(9.8, Units.m),
+                LengthUnit(0.1, Units.m),
             ),
             (
-                SpatialVector(LengthUnit(-0.100001), LengthUnit(65.1)),
-                LengthUnit(0.00000001),
-                LengthUnit(12.5),
+                SpatialVector(
+                    LengthUnit(-0.100001, Units.m), LengthUnit(65.1, Units.m)
+                ),
+                LengthUnit(0.00000001, Units.m),
+                LengthUnit(12.5, Units.m),
             ),
             (
                 SpatialVector(LengthUnit(-987.1), LengthUnit(-12.3)),
                 LengthUnit(-987.1),
-                LengthUnit(0.00001),
+                LengthUnit(0.00001, Units.m),
             ),
             (
-                SpatialVector(LengthUnit(0.0), LengthUnit(0.0)),
-                LengthUnit(0.3),
+                SpatialVector(
+                    LengthUnit(0.0, Units.m), LengthUnit(0.0, Units.m)
+                ),
+                LengthUnit(0.3, Units.m),
                 LengthUnit(-0.001),
             ),
         ],
@@ -59,8 +67,12 @@ class TestSpatialVector:
         "spatial_vector, other, result",
         [
             (
-                SpatialVector(LengthUnit(-10.12), LengthUnit(34.12)),
-                SpatialVector(LengthUnit(-10.12), LengthUnit(34.12)),
+                SpatialVector(
+                    LengthUnit(-10.12, Units.m), LengthUnit(34.12, Units.m)
+                ),
+                SpatialVector(
+                    LengthUnit(-10.12, Units.m), LengthUnit(34.12, Units.m)
+                ),
                 True,
             ),
             (
@@ -69,33 +81,58 @@ class TestSpatialVector:
                 True,
             ),
             (
-                SpatialVector(LengthUnit(612.12), LengthUnit(-73.1)),
-                SpatialVector(LengthUnit(612.12), LengthUnit(-73.1)),
+                SpatialVector(
+                    LengthUnit(612.12, Units.m), LengthUnit(-73.1, Units.m)
+                ),
+                SpatialVector(
+                    LengthUnit(612.12, Units.m), LengthUnit(-73.1, Units.m)
+                ),
                 True,
             ),
             (
-                SpatialVector(LengthUnit(9.00001), LengthUnit(0.00001)),
-                SpatialVector(LengthUnit(9.00001), LengthUnit(0.00001)),
+                SpatialVector(
+                    LengthUnit(9.00001, Units.m), LengthUnit(0.00001, Units.m)
+                ),
+                SpatialVector(
+                    LengthUnit(9.00001, Units.m), LengthUnit(0.00001, Units.m)
+                ),
                 True,
             ),
             (
-                SpatialVector(LengthUnit(-10.12), LengthUnit(34.12)),
-                SpatialVector(LengthUnit(-10.1200001), LengthUnit(34.11)),
+                SpatialVector(
+                    LengthUnit(-10.12, Units.m), LengthUnit(34.12, Units.m)
+                ),
+                SpatialVector(
+                    LengthUnit(-10.1200001, Units.m),
+                    LengthUnit(34.11, Units.m),
+                ),
                 False,
             ),
             (
-                SpatialVector(LengthUnit(912.111), LengthUnit(4.6)),
-                SpatialVector(LengthUnit(912.111), LengthUnit(-4.6)),
+                SpatialVector(
+                    LengthUnit(912.111, Units.m), LengthUnit(4.6, Units.m)
+                ),
+                SpatialVector(
+                    LengthUnit(912.111, Units.m), LengthUnit(-4.6, Units.m)
+                ),
                 False,
             ),
             (
-                SpatialVector(LengthUnit(0.0000001), LengthUnit(65.11)),
-                SpatialVector(LengthUnit(0), LengthUnit(65.11)),
+                SpatialVector(
+                    LengthUnit(0.0000001, Units.m), LengthUnit(65.11, Units.m)
+                ),
+                SpatialVector(
+                    LengthUnit(0, Units.m), LengthUnit(65.11, Units.m)
+                ),
                 False,
             ),
             (
-                SpatialVector(LengthUnit(67.65), LengthUnit(-76.1111)),
-                SpatialVector(LengthUnit(-76.1111), LengthUnit(67.65)),
+                SpatialVector(
+                    LengthUnit(67.65, Units.m), LengthUnit(-76.1111, Units.m)
+                ),
+                SpatialVector(
+                    LengthUnit(-76.1111, Units.m), LengthUnit(67.65, Units.m)
+                ),
                 False,
             ),
         ],

--- a/cpp/pycore/test/geometry/spatial_vector_test.py
+++ b/cpp/pycore/test/geometry/spatial_vector_test.py
@@ -8,7 +8,7 @@ class TestSpatialVector:
         [
             (LengthUnit(-12.0, Units.m), LengthUnit(435.1, Units.m)),
             (LengthUnit(12.0, Units.m), LengthUnit(-71.5, Units.m)),
-            (LengthUnit(-1.010101), LengthUnit(-0.0)),
+            (LengthUnit(-1.010101, Units.m), LengthUnit(-0.0, Units.m)),
             (LengthUnit(561.5, Units.m), LengthUnit(46.11, Units.m)),
             (LengthUnit(-0.01, Units.m), LengthUnit(73.12, Units.m)),
         ],
@@ -25,7 +25,7 @@ class TestSpatialVector:
                 SpatialVector(
                     LengthUnit(-10.12, Units.m), LengthUnit(34.12, Units.m)
                 ),
-                LengthUnit(-12.45),
+                LengthUnit(-12.45, Units.m),
                 LengthUnit(657, Units.m),
             ),
             (
@@ -43,8 +43,10 @@ class TestSpatialVector:
                 LengthUnit(12.5, Units.m),
             ),
             (
-                SpatialVector(LengthUnit(-987.1), LengthUnit(-12.3)),
-                LengthUnit(-987.1),
+                SpatialVector(
+                    LengthUnit(-987.1, Units.m), LengthUnit(-12.3, Units.m)
+                ),
+                LengthUnit(-987.1, Units.m),
                 LengthUnit(0.00001, Units.m),
             ),
             (
@@ -52,7 +54,7 @@ class TestSpatialVector:
                     LengthUnit(0.0, Units.m), LengthUnit(0.0, Units.m)
                 ),
                 LengthUnit(0.3, Units.m),
-                LengthUnit(-0.001),
+                LengthUnit(-0.001, Units.m),
             ),
         ],
     )
@@ -76,8 +78,12 @@ class TestSpatialVector:
                 True,
             ),
             (
-                SpatialVector(LengthUnit(-0.00004), LengthUnit(-123.4)),
-                SpatialVector(LengthUnit(-0.00004), LengthUnit(-123.4)),
+                SpatialVector(
+                    LengthUnit(-0.00004, Units.m), LengthUnit(-123.4, Units.m)
+                ),
+                SpatialVector(
+                    LengthUnit(-0.00004, Units.m), LengthUnit(-123.4, Units.m)
+                ),
                 True,
             ),
             (

--- a/cpp/pycore/test/geometry/special_area_test.py
+++ b/cpp/pycore/test/geometry/special_area_test.py
@@ -71,7 +71,9 @@ class TestSpecialArea:
                             Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
+                            LengthUnit(-6.1, Units.m),
+                            LengthUnit(-6.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-1.5, Units.m),

--- a/cpp/pycore/test/geometry/special_area_test.py
+++ b/cpp/pycore/test/geometry/special_area_test.py
@@ -6,6 +6,7 @@ from jpscore.geometry import (
     Level,
     LineSegment,
     SpecialArea,
+    Units,
 )
 
 
@@ -18,22 +19,34 @@ class TestSpecialArea:
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(0.1), LengthUnit(0.65), Level(3)
+                            LengthUnit(0.1, Units.m),
+                            LengthUnit(0.65, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(0.45), LengthUnit(61.1), Level(3)
+                            LengthUnit(0.45, Units.m),
+                            LengthUnit(61.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(1.3), LengthUnit(-12.1), Level(3)
+                            LengthUnit(1.3, Units.m),
+                            LengthUnit(-12.1, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(5.1), LengthUnit(-41.0), Level(3)
+                            LengthUnit(5.1, Units.m),
+                            LengthUnit(-41.0, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(45.1), LengthUnit(-45.11), Level(3)
+                            LengthUnit(45.1, Units.m),
+                            LengthUnit(-45.11, Units.m),
+                            Level(3),
                         ),
                         Coordinate(
-                            LengthUnit(7.11), LengthUnit(45.1), Level(3)
+                            LengthUnit(7.11, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(3),
                         ),
                     ]
                 ),
@@ -43,25 +56,37 @@ class TestSpecialArea:
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(1.41), LengthUnit(34.1), Level(-3)
+                            LengthUnit(1.41, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-1.6), LengthUnit(12.1), Level(-3)
+                            LengthUnit(-1.6, Units.m),
+                            LengthUnit(12.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
                             LengthUnit(-6.1), LengthUnit(-6.1), Level(-3)
                         ),
                         Coordinate(
-                            LengthUnit(-1.5), LengthUnit(34.1), Level(-3)
+                            LengthUnit(-1.5, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(30.11), LengthUnit(15.1), Level(-3)
+                            LengthUnit(30.11, Units.m),
+                            LengthUnit(15.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                     ]
                 ),
@@ -82,13 +107,19 @@ class TestSpecialArea:
                     Area(
                         [
                             Coordinate(
-                                LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                                LengthUnit(45.54, Units.m),
+                                LengthUnit(45.1, Units.m),
+                                Level(-3),
                             ),
                             Coordinate(
-                                LengthUnit(1.41), LengthUnit(34.1), Level(-3)
+                                LengthUnit(1.41, Units.m),
+                                LengthUnit(34.1, Units.m),
+                                Level(-3),
                             ),
                             Coordinate(
-                                LengthUnit(-1.6), LengthUnit(12.1), Level(-3)
+                                LengthUnit(-1.6, Units.m),
+                                LengthUnit(12.1, Units.m),
+                                Level(-3),
                             ),
                         ]
                     ),
@@ -98,13 +129,19 @@ class TestSpecialArea:
                 Area(
                     [
                         Coordinate(
-                            LengthUnit(45.54), LengthUnit(45.1), Level(-3)
+                            LengthUnit(45.54, Units.m),
+                            LengthUnit(45.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(1.41), LengthUnit(34.1), Level(-3)
+                            LengthUnit(1.41, Units.m),
+                            LengthUnit(34.1, Units.m),
+                            Level(-3),
                         ),
                         Coordinate(
-                            LengthUnit(-1.6), LengthUnit(12.1), Level(-3)
+                            LengthUnit(-1.6, Units.m),
+                            LengthUnit(12.1, Units.m),
+                            Level(-3),
                         ),
                     ],
                 ),


### PR DESCRIPTION
Bindings for the constructor and the read only properties. 
The constructor requires two arguments. The quantity and the unit of this quantity. Unfortunately we need a big switch statement which is matching the unit with a literal of the same unit to select the correct template function. Can be called in python like: 
``` py
lu = LengthUnit(5.0, Units.mm)
```
The read only property call the getter of the length unit to retrieve the quantity in the desired unit. Can be called like: 
``` py
print(lu.um)
```
Unfortunately a lot of copy and paste since templated functions can not be set by dynmic variables. 

Attention the PR is based on #44 and will be based onto main after merge of #44. 