### PR TITLE
Polygon equality should ignore polygon orientation

### DIFF
--- a/cpp/libcore/source/geometry/helper/polygon_helper.cpp
+++ b/cpp/libcore/source/geometry/helper/polygon_helper.cpp
@@ -101,10 +101,20 @@ auto jps::geometry::checkPolygonEquality(
     doubled_polygon.insert(std::end(doubled_polygon), std::begin(p_polygon), std::end(p_polygon));
 
     auto found = std::search(
-        std::begin(doubled_polygon),
-        std::end(doubled_polygon),
-        std::begin(p_other),
-        std::end(p_other));
+        std::cbegin(doubled_polygon),
+        std::cend(doubled_polygon),
+        std::cbegin(p_other),
+        std::cend(p_other));
 
-    return found != std::end(doubled_polygon);
+    if(found != std::end(doubled_polygon)) {
+        return true;
+    }
+
+    auto found_reverse = std::search(
+        std::cbegin(doubled_polygon),
+        std::cend(doubled_polygon),
+        std::crbegin(p_other),
+        std::crend(p_other));
+
+    return found_reverse != std::end(doubled_polygon);
 }

--- a/cpp/libcore/source/geometry/helper/polygon_helper.hpp
+++ b/cpp/libcore/source/geometry/helper/polygon_helper.hpp
@@ -34,7 +34,16 @@ auto getPolygonCoordinates(std::vector<LineSegment> & p_line_segments) -> std::v
 ///
 /// It will be checked if \p p_polygon and \p p_other are a representation of the same polygon. Two
 /// polygons are considered equal if the lists contain the same points in the same order, cyclic
-/// permutations (as in std::rotate) are allowed.
+/// permutations (as in std::rotate) are allowed. They are also considered equal if one of them is
+/// reversed.
+///
+/// Examples:
+/// (A, B, C, D) == (B, C, D, A) -> true
+/// (A, B, C, D) == (D, C, B, A) -> true
+/// (A, B, C, D) == (B, A, D, C) -> true
+///
+/// (A, B, C, D) == (B, A, C, D) -> false
+/// (A, B, C, D) == (A, B, C, D, E) -> false
 ///
 /// \param p_polygon representation of one polygon
 /// \param p_other representation of the other polygon.

--- a/cpp/libcore/test/geometry/test_helper.cpp
+++ b/cpp/libcore/test/geometry/test_helper.cpp
@@ -188,13 +188,19 @@ TEST(GeometryHelper, checkPolygonEquality) // NOLINTLINE
     // same values
     std::vector<Coordinate> equal{reference_coordinates}; // NOLINTLINE
     EXPECT_TRUE(checkPolygonEquality(equal, reference_coordinates));
+    std::vector<Coordinate> equal_reversed{std::rbegin(equal), std::rend(equal)};
+    EXPECT_TRUE(checkPolygonEquality(equal_reversed, reference_coordinates));
 
     // rotate vector
     std::rotate(std::begin(equal), std::begin(equal) + 5, std::end(equal));
     EXPECT_TRUE(checkPolygonEquality(equal, reference_coordinates));
+    std::reverse_copy(std::begin(equal), std::end(equal), std::begin(equal_reversed));
+    EXPECT_TRUE(checkPolygonEquality(equal_reversed, reference_coordinates));
 
     std::rotate(std::begin(equal), std::begin(equal) + 5, std::end(equal));
     EXPECT_TRUE(checkPolygonEquality(equal, reference_coordinates));
+    std::reverse_copy(std::begin(equal), std::end(equal), std::begin(equal_reversed));
+    EXPECT_TRUE(checkPolygonEquality(equal_reversed, reference_coordinates));
 
     std::vector<Coordinate> empty;
     EXPECT_FALSE(checkPolygonEquality(empty, reference_coordinates));
@@ -202,8 +208,13 @@ TEST(GeometryHelper, checkPolygonEquality) // NOLINTLINE
     std::vector<Coordinate> subset{reference_coordinates};
     subset.pop_back();
     EXPECT_FALSE(checkPolygonEquality(subset, reference_coordinates));
+    std::vector<Coordinate> subset_reversed{std::rbegin(subset), std::rend(subset)};
+    EXPECT_FALSE(checkPolygonEquality(subset_reversed, reference_coordinates));
 
     std::vector<Coordinate> switch_two_elements{reference_coordinates};
     std::iter_swap(std::begin(switch_two_elements), std::begin(switch_two_elements) + 3);
     EXPECT_FALSE(checkPolygonEquality(switch_two_elements, reference_coordinates));
+    std::vector<Coordinate> switch_two_reversed{
+        std::rbegin(switch_two_elements), std::rend(switch_two_elements)};
+    EXPECT_FALSE(checkPolygonEquality(switch_two_reversed, reference_coordinates));
 }


### PR DESCRIPTION
After discussion: two polygons should be considered equal ignoring their orientation (clockwise/counterclockwise).

Example:
```
(A, B, C, D) == (B, C, D, A) -> true
(A, B, C, D) == (D, C, B, A) -> true
(A, B, C, D) == (B, A, D, C) -> true

(A, B, C, D) == (B, A, C, D) -> false
(A, B, C, D) == (A, B, C, D, E) -> false
```