### PR TITLE
Enable compiler warnings and fix them

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,6 +18,32 @@ enforce_build_type_is_set()
 add_clang_tidy_support_option()
 
 ################################################################################
+# Compilation flags
+################################################################################
+# Note: Setting global compile flags via CMAKE_CXX_FLAGS has the drawback that
+#       generator expressions cannot be used. This leads to all kind of
+#       conditional adding of flags. It is generally preferable to use generator
+#       expresssions.
+#
+# WARNING: Do not break the lines, each option has to be on its own line or
+#          CMake will enclose multiple flags in '' which the compiler then
+#          treats as a single flag and does not understand.
+list(APPEND COMMON_COMPILE_OPTIONS
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wextra>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wpedantic>
+#        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Werror>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wconversion>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wimplicit-fallthrough>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wsign-conversion>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-fdiagnostics-color=always>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4>
+#        $<$<CXX_COMPILER_ID:MSVC>:/WX>
+        $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
+        -fPIC
+)
+
+################################################################################
 # Dependencies
 ################################################################################
 find_package(GTest 1.10 CONFIG REQUIRED)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -31,14 +31,14 @@ add_clang_tidy_support_option()
 list(APPEND COMMON_COMPILE_OPTIONS
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wextra>
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wpedantic>
-#        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Werror>
+#        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wpedantic>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Werror>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wconversion>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wimplicit-fallthrough>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wsign-conversion>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-fdiagnostics-color=always>
         $<$<CXX_COMPILER_ID:MSVC>:/W4>
-#        $<$<CXX_COMPILER_ID:MSVC>:/WX>
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>
         $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
         -fPIC
 )

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -31,12 +31,13 @@ add_clang_tidy_support_option()
 list(APPEND COMMON_COMPILE_OPTIONS
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wextra>
-#        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wpedantic>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Werror>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wconversion>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wimplicit-fallthrough>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wsign-conversion>
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-fdiagnostics-color=always>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wpedantic>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-gnu-zero-variadic-macro-arguments>
         $<$<CXX_COMPILER_ID:MSVC>:/W4>
         $<$<CXX_COMPILER_ID:MSVC>:/WX>
         $<$<CXX_COMPILER_ID:MSVC>:/EHsc>

--- a/cpp/libcore/source/CMakeLists.txt
+++ b/cpp/libcore/source/CMakeLists.txt
@@ -37,5 +37,5 @@ target_link_libraries(core
 )
 
 target_compile_options(core PRIVATE
-    -fPIC
+    ${COMMON_COMPILE_OPTIONS}
 )

--- a/cpp/libcore/source/geometry/helper/polygon_helper.hpp
+++ b/cpp/libcore/source/geometry/helper/polygon_helper.hpp
@@ -52,5 +52,5 @@ auto getPolygonCoordinates(std::vector<LineSegment> & p_line_segments) -> std::v
 auto checkPolygonEquality(
     std::vector<Coordinate> const & p_polygon,
     std::vector<Coordinate> const & p_other) -> bool;
-}; // namespace geometry
+} // namespace geometry
 } // namespace jps

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -186,56 +186,71 @@ inline auto operator*(double p_scalar, jps::LengthUnit p_lu) -> jps::LengthUnit
 {
     return p_lu * p_scalar;
 }
+
 /// User defined literals for all units
+/// Note that the cast is needed to silence compiler warning about narrowing down precision
 inline auto operator"" _um(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::um>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::um>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _mm(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::mm>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::mm>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _cm(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::cm>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::cm>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _dm(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::dm>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::dm>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _m(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::m>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::m>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _km(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::km>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::km>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 
 /// User defined literals for integrals
+/// Note that the cast is needed to silence compiler warning about narrowing down precision
 inline auto operator"" _um(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::um>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::um>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _mm(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::mm>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::mm>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _cm(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::cm>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::cm>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _dm(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::dm>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::dm>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _m(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::m>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::m>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 inline auto operator"" _km(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::km>(static_cast<double>(p_quantity));
+    return jps::makeLengthUnit<jps::Units::km>(
+        static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
 
 namespace fmt

--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -189,53 +189,53 @@ inline auto operator*(double p_scalar, jps::LengthUnit p_lu) -> jps::LengthUnit
 /// User defined literals for all units
 inline auto operator"" _um(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::um>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::um>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _mm(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::mm>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::mm>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _cm(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::cm>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::cm>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _dm(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::dm>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::dm>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _m(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::m>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::m>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _km(long double p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::km>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::km>(static_cast<double>(p_quantity));
 }
 
 /// User defined literals for integrals
 inline auto operator"" _um(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::um>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::um>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _mm(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::mm>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::mm>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _cm(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::cm>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::cm>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _dm(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::dm>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::dm>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _m(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::m>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::m>(static_cast<double>(p_quantity));
 }
 inline auto operator"" _km(unsigned long long p_quantity) -> jps::LengthUnit
 {
-    return jps::makeLengthUnit<jps::Units::km>(p_quantity);
+    return jps::makeLengthUnit<jps::Units::km>(static_cast<double>(p_quantity));
 }
 
 namespace fmt

--- a/cpp/libcore/source/geometry/line_segment.hpp
+++ b/cpp/libcore/source/geometry/line_segment.hpp
@@ -53,6 +53,6 @@ struct formatter<jps::LineSegment> {
             "LINE_SEGMENT: ({}) -- ({})",
             p_line_segment.getStart(),
             p_line_segment.getEnd());
-    };
+    }
 };
 } // namespace fmt

--- a/cpp/libcore/source/geometry/world_builder.cpp
+++ b/cpp/libcore/source/geometry/world_builder.cpp
@@ -1,14 +1,17 @@
 #include "world_builder.hpp"
 
 auto jps::WorldBuilder::addLineSegment(
-    const jps::Level & p_level,
-    const jps::LineSegment & p_segment) -> void
+    const jps::Level & /*p_level*/,
+    const jps::LineSegment &
+    /*p_segment*/) -> void
 {
     // TODO: ensure that level of coordinates of the segment and p-level are the same, add to map
 }
 
-auto jps::WorldBuilder::addSpecialArea(const jps::Level & p_level, const jps::SpecialArea & p_area)
-    -> void
+auto jps::WorldBuilder::addSpecialArea(
+    const jps::Level & /*p_level*/,
+    const jps::SpecialArea &
+    /*p_area*/) -> void
 {
     // TODO: check if area id at given level already exists, add to map
 }

--- a/cpp/libcore/source/log.cpp
+++ b/cpp/libcore/source/log.cpp
@@ -25,13 +25,13 @@ public:
     void setCallback(Logging::Level p_level, Logging::LogCallback p_callback)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        m_callbacks[toUnderlying(p_level)] = std::move(p_callback);
+        m_callbacks[static_cast<size_t>(toUnderlying(p_level))] = std::move(p_callback);
     }
 
     void msg(Logging::Level p_level, std::string_view p_msg)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        if(auto & cb = m_callbacks[toUnderlying(p_level)]; cb) {
+        if(auto & cb = m_callbacks[static_cast<size_t>(toUnderlying(p_level))]; cb) {
             cb(p_msg);
         }
     }

--- a/cpp/libcore/source/simulation.cpp
+++ b/cpp/libcore/source/simulation.cpp
@@ -6,5 +6,5 @@ namespace jps
 Simulation::Simulation()
 {
     LOG_DEBUG("Simulator ctor");
-};
-}; // namespace jps
+}
+} // namespace jps

--- a/cpp/libcore/test/CMakeLists.txt
+++ b/cpp/libcore/test/CMakeLists.txt
@@ -29,5 +29,5 @@ gtest_discover_tests(test-core)
 
 
 target_compile_options(test-core PRIVATE
-    -fPIC
+    ${COMMON_COMPILE_OPTIONS}
 )

--- a/cpp/libcore/test/CMakeLists.txt
+++ b/cpp/libcore/test/CMakeLists.txt
@@ -27,7 +27,19 @@ target_link_libraries(test-core
 
 gtest_discover_tests(test-core)
 
+list(APPEND TEST_COMPILE_OPTIONS
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wextra>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wconversion>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wimplicit-fallthrough>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wsign-conversion>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-fdiagnostics-color=always>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-self-assign-overloaded>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4>
+        $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
+        -fPIC
+        )
 
 target_compile_options(test-core PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+    ${TEST_COMPILE_OPTIONS}
 )

--- a/cpp/pycore/source/CMakeLists.txt
+++ b/cpp/pycore/source/CMakeLists.txt
@@ -32,3 +32,8 @@ target_link_libraries(jpscore
     PRIVATE
         core
 )
+
+target_compile_options(jpscore PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+


### PR DESCRIPTION
Enables some compiler warnings, we need to discuss which one we should activate.

Currently `-Werror` and `\WX` are turned off, but will be turned on once every warning is fixed.

Closes #56 