### PR TITLE
Parse unit information in dxf file

### DIFF
--- a/jps/jupedsim/IO/worldparser.py
+++ b/jps/jupedsim/IO/worldparser.py
@@ -48,7 +48,7 @@ class WorldParser:
         log_info("Building world ...")
         self.m_jps_world_builder = geometry.WorldBuilder()
 
-        #TODO check if the other parsing functions can be static
+        # TODO check if the other parsing functions can be static
         self.__parseLevels()
 
         return self.m_jps_world_builder

--- a/jps/jupedsim/IO/worldparser.py
+++ b/jps/jupedsim/IO/worldparser.py
@@ -114,12 +114,12 @@ class WorldParser:
         :raises JPSGeometryException: if chosen header variables are not supported
         """
 
-        if not WorldParser.checkMetricUnit(
-            doc
-        ) or not WorldParser.checkDecimalUnit(doc):
-            raise JPSGeometryException(
-                "Only metric units in decimal format are supported."
-            )
+        if not WorldParser.checkMetricUnit(doc):
+            raise JPSGeometryException("Only metric units are supported.")
+
+        # Note: changing the decimal unit did not have any effect on the units when working wih QCAD or LibreCAD. This might be only important for labels or the representation in the editor.
+        if not WorldParser.checkDecimalUnit(doc):
+            raise JPSGeometryException("Only decimal format is supported.")
 
     def __parseCoordinates(
         self, line: str, p_level: geometry.Level

--- a/jps/jupedsim/IO/worldparser.py
+++ b/jps/jupedsim/IO/worldparser.py
@@ -96,13 +96,14 @@ class WorldParser:
         lower_left_corner = doc.header['$EXTMIN']
         """
 
-        if WorldParser.checkMetricUnit(doc) or WorldParser.checkDecimalUnit(doc):
+        if not WorldParser.checkMetricUnit(
+            doc
+        ) or not WorldParser.checkDecimalUnit(doc):
             # TODO throw exception
             log_error("Only metric units in decimal format are supported.")
 
         # TODO catch exception
         self.m_unit = WorldParser.readLengthUnitType(doc)
-
 
     def __parseCoordinates(
         self, line: str, p_level: geometry.Level

--- a/jps/jupedsim/IO/worldparser.py
+++ b/jps/jupedsim/IO/worldparser.py
@@ -2,8 +2,7 @@ import re
 from typing import List
 
 import ezdxf
-from jpscore import geometry
-from jpscore import JPSGeometryException
+from jpscore import JPSGeometryException, geometry
 from jupedsim.util.loghelper import log_debug, log_error, log_info, log_warning
 
 
@@ -86,7 +85,9 @@ class WorldParser:
         elif dxf_unit == 14:
             return geometry.Units.dm
 
-        raise JPSGeometryException("Defined length unit is not supported. Supported length units: um, mm, cm, dm, m, km")
+        raise JPSGeometryException(
+            "Defined length unit is not supported. Supported length units: um, mm, cm, dm, m, km"
+        )
 
     def __parseHeader(self, doc: ezdxf.document.Drawing) -> None:
         """
@@ -103,7 +104,9 @@ class WorldParser:
         if not WorldParser.checkMetricUnit(
             doc
         ) or not WorldParser.checkDecimalUnit(doc):
-            raise JPSGeometryException("Only metric units in decimal format are supported.")
+            raise JPSGeometryException(
+                "Only metric units in decimal format are supported."
+            )
 
         self.m_unit = WorldParser.readLengthUnitType(doc)
 

--- a/jps/jupedsim/IO/worldparser.py
+++ b/jps/jupedsim/IO/worldparser.py
@@ -3,6 +3,7 @@ from typing import List
 
 import ezdxf
 from jpscore import geometry
+from jpscore import JPSGeometryException
 from jupedsim.util.loghelper import log_debug, log_error, log_info, log_warning
 
 
@@ -68,6 +69,7 @@ class WorldParser:
         Parsing units according to [INSUNITS documentation](https://knowledge.autodesk.com/de/support/autocad/learn-explore/caas/CloudHelp/cloudhelp/2018/DEU/AutoCAD-Core/files/GUID-A58A87BB-482B-4042-A00A-EEF55A2B4FD8-htm.html)
         :param doc: document drawing of dxf file
         :return: corresponding geometry.Units object
+        :raises JPSGeometryException: if length unit set in dxf file is not um, mm, cm, dm, m or km
         """
 
         dxf_unit = doc.header["$INSUNITS"]
@@ -84,8 +86,7 @@ class WorldParser:
         elif dxf_unit == 14:
             return geometry.Units.dm
 
-        # TODO throw exception
-        log_error("Length unit is not supported.")
+        raise JPSGeometryException("Defined length unit is not supported. Supported length units: um, mm, cm, dm, m, km")
 
     def __parseHeader(self, doc: ezdxf.document.Drawing) -> None:
         """
@@ -94,15 +95,16 @@ class WorldParser:
         NOTE: these headers are not available in qcad file:
         upper_right_corner = doc.header['$EXTMAX']
         lower_left_corner = doc.header['$EXTMIN']
+
+        :param doc: document drawing of dxf file
+        :raises JPSGeometryException: if chosen header variables are not supported
         """
 
         if not WorldParser.checkMetricUnit(
             doc
         ) or not WorldParser.checkDecimalUnit(doc):
-            # TODO throw exception
-            log_error("Only metric units in decimal format are supported.")
+            raise JPSGeometryException("Only metric units in decimal format are supported.")
 
-        # TODO catch exception
         self.m_unit = WorldParser.readLengthUnitType(doc)
 
     def __parseCoordinates(

--- a/jps/jupedsim/IO/worldparser.py
+++ b/jps/jupedsim/IO/worldparser.py
@@ -13,10 +13,17 @@ class WorldParser:
 
     def __init__(self, p_input_file: str):
         """
-        Initialization with a dxf file. In case of valid file format Lines and SpecialAreas are parsed.
+        Initialization with a dxf file name.
         :param p_input_file: name of the dxf file
         """
         self.m_input_file = p_input_file
+
+    def parse(self) -> geometry.WorldBuilder:
+        """
+        Parsing header information and entities on different levels. In case of valid file format Lines and SpecialAreas are parsed.
+        :return: geometry.WorldBuilder object
+        :raises IOError, ezdxf.DXFStructureError: if file not found or if invalid dxf format
+        """
 
         # try to open file
         try:
@@ -39,7 +46,10 @@ class WorldParser:
         # build World
         log_info("Building world ...")
         self.m_jps_world_builder = geometry.WorldBuilder()
+
         self.__parseLevels()
+
+        return self.m_jps_world_builder
 
     @staticmethod
     def checkMetricUnit(doc: ezdxf.document.Drawing) -> bool:

--- a/jps/jupedsim/IO/worldparser.py
+++ b/jps/jupedsim/IO/worldparser.py
@@ -41,12 +41,14 @@ class WorldParser:
         self.m_msp = doc.modelspace()
 
         # parse header variables
-        self.__parseHeader(doc)
+        WorldParser.checkHeader(doc)
+        self.m_unit = WorldParser.readLengthUnitType(doc)
 
         # build World
         log_info("Building world ...")
         self.m_jps_world_builder = geometry.WorldBuilder()
 
+        #TODO check if the other parsing functions can be static
         self.__parseLevels()
 
         return self.m_jps_world_builder
@@ -99,7 +101,8 @@ class WorldParser:
             "Defined length unit is not supported. Supported length units: um, mm, cm, dm, m, km"
         )
 
-    def __parseHeader(self, doc: ezdxf.document.Drawing) -> None:
+    @staticmethod
+    def checkHeader(doc: ezdxf.document.Drawing) -> None:
         """
         Reads in meta data defined in header of the dxf file.
         Header variables can be found on [autodesk header variables](http://help.autodesk.com/view/OARX/2018/ENU/?guid=GUID-A85E8E67-27CD-4C59-BE61-4DC9FADBE74A)
@@ -117,8 +120,6 @@ class WorldParser:
             raise JPSGeometryException(
                 "Only metric units in decimal format are supported."
             )
-
-        self.m_unit = WorldParser.readLengthUnitType(doc)
 
     def __parseCoordinates(
         self, line: str, p_level: geometry.Level

--- a/jps/jupedsim/tests/IO/test_worldparser.py
+++ b/jps/jupedsim/tests/IO/test_worldparser.py
@@ -1,0 +1,60 @@
+import ezdxf
+import pytest
+from jpscore import JPSGeometryException, geometry
+from jupedsim.IO.worldparser import WorldParser
+
+
+class TestWorldParser:
+    @pytest.mark.parametrize(
+        "insunit, result",
+        [
+            (4, geometry.Units.mm),
+            (5, geometry.Units.cm),
+            (6, geometry.Units.m),
+            (7, geometry.Units.km),
+            (13, geometry.Units.um),
+            (14, geometry.Units.dm),
+        ],
+    )
+    def test_length_unit_correct(self, insunit, result):
+        doc = ezdxf.new()
+        doc.header["$INSUNITS"] = insunit
+        unit = WorldParser.readLengthUnitType(doc)
+        assert unit == result
+
+    @pytest.mark.parametrize(
+        "insunit",
+        [-1, 0, 1, 2, 3, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21],
+    )
+    def test_length_unit_incorrect(self, insunit):
+        doc = ezdxf.new()
+        doc.header["$INSUNITS"] = insunit
+
+        with pytest.raises(JPSGeometryException):
+            WorldParser.readLengthUnitType(doc)
+
+    @pytest.mark.parametrize(
+        "measurement, result", [(-1, False), (0, False), (1, True), (2, False)]
+    )
+    def test_metric_unit(self, measurement, result):
+        doc = ezdxf.new()
+        doc.header["$MEASUREMENT"] = measurement
+        assert WorldParser.checkMetricUnit(doc) == result
+
+    @pytest.mark.parametrize(
+        "dimlunit, result",
+        [
+            (-1, False),
+            (0, False),
+            (1, False),
+            (2, True),
+            (3, False),
+            (4, False),
+            (5, False),
+            (6, False),
+        ],
+    )
+    def test_decimal_unit(self, dimlunit, result):
+        doc = ezdxf.new()
+        doc.header["$DIMLUNIT"] = dimlunit
+        assert WorldParser.checkDecimalUnit(doc) == result

--- a/jps/jupedsim/tests/IO/test_worldparser.py
+++ b/jps/jupedsim/tests/IO/test_worldparser.py
@@ -58,3 +58,31 @@ class TestWorldParser:
         doc = ezdxf.new()
         doc.header["$DIMLUNIT"] = dimlunit
         assert WorldParser.checkDecimalUnit(doc) == result
+
+    @pytest.mark.parametrize(
+        "measurement, dimlunit",
+        [
+            (0, 0),
+            (0, 2),
+            (1, 0),
+        ],
+    )
+    def test_check_header_exception(self, measurement, dimlunit):
+        doc = ezdxf.new()
+        doc.header["$MEASUREMENT"] = measurement
+        doc.header["$DIMLUNIT"] = dimlunit
+
+        with pytest.raises(JPSGeometryException):
+            WorldParser.checkHeader(doc)
+
+    def test_check_header_no_exception(self):
+        doc = ezdxf.new()
+        doc.header["$MEASUREMENT"] = 1
+        doc.header["$DIMLUNIT"] = 2
+
+        try:
+            WorldParser.checkHeader(doc)
+        except JPSGeometryException:
+            pytest.fail(
+                "Unexpected JPSGeometryException when checking header parameters."
+            )


### PR DESCRIPTION
The world parser is extended by reading in metadata stored in header variables of the dxf file. Units of the entities are checked. Only metric and decimal units that are defined in the `Units` enum are valid input formats. 

For a valid format, the data of the entities are parsed to geometry objects based on the corresponding LengthUnits.