### PR TITLE
Make LengthUnit constexpr

### DIFF
--- a/cpp/libcore/source/geometry/length_unit.hpp
+++ b/cpp/libcore/source/geometry/length_unit.hpp
@@ -44,7 +44,7 @@ template <typename QuantityType, Units Unit>
 struct LengthUnitParams {
     /// The quantity for the LengthUnit creation in Unit
     const QuantityType quantity; // NOLINT(misc-non-private-member-variables-in-classes)
-    explicit LengthUnitParams(QuantityType p_quantity) : quantity{p_quantity} {}
+    constexpr explicit LengthUnitParams(QuantityType p_quantity) : quantity{p_quantity} {}
 };
 } // namespace details
 
@@ -82,7 +82,7 @@ public:
     ///
     /// @tparam Unit is the input unit of the quantity.
     template <Units Unit>
-    explicit LengthUnit(details::LengthUnitParams<QuantityType, Unit> const & p_params) :
+    constexpr explicit LengthUnit(details::LengthUnitParams<QuantityType, Unit> const & p_params) :
         m_quantity{details::scaleQuantity<Unit, RESOLUTION>(p_params.quantity)}
     {
     }
@@ -94,49 +94,49 @@ public:
     /// @tparam Unit target unit for the quantity
     /// @returns the quantity in the target Unit
     template <Units Unit = RESOLUTION>
-    auto get() const -> QuantityType
+    constexpr auto get() const -> QuantityType
     {
         return details::scaleQuantity<RESOLUTION, Unit>(m_quantity);
     }
 
-    auto operator+=(LengthUnit const & p_other) noexcept -> LengthUnit &
+    constexpr auto operator+=(LengthUnit const & p_other) noexcept -> LengthUnit &
     {
         m_quantity += p_other.m_quantity;
         return *this;
     }
 
-    auto operator-=(LengthUnit const & p_other) noexcept -> LengthUnit &
+    constexpr auto operator-=(LengthUnit const & p_other) noexcept -> LengthUnit &
     {
         m_quantity -= p_other.m_quantity;
         return *this;
     }
 
-    auto operator<(LengthUnit const & p_other) const noexcept -> bool
+    constexpr auto operator<(LengthUnit const & p_other) const noexcept -> bool
     {
         return m_quantity < p_other.m_quantity;
     }
 
-    auto operator>(LengthUnit const & p_other) const noexcept -> bool
+    constexpr auto operator>(LengthUnit const & p_other) const noexcept -> bool
     {
         return m_quantity > p_other.m_quantity;
     }
 
-    auto operator==(LengthUnit const & p_other) const noexcept -> bool
+    constexpr auto operator==(LengthUnit const & p_other) const noexcept -> bool
     {
         return m_quantity == p_other.m_quantity;
     }
 
-    auto operator!=(LengthUnit const & p_other) const noexcept -> bool
+    constexpr auto operator!=(LengthUnit const & p_other) const noexcept -> bool
     {
         return m_quantity != p_other.m_quantity;
     }
 
     // friend functions
-    friend auto operator-(jps::LengthUnit p_lu) -> jps::LengthUnit;
+    friend constexpr auto operator-(jps::LengthUnit p_lu) -> jps::LengthUnit;
 
-    friend auto operator*(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit;
+    friend constexpr auto operator*(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit;
 
-    friend auto operator/(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit;
+    friend constexpr auto operator/(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit;
 
 private:
     /// Stores the length unit quantity stored in RESOLUTION
@@ -149,20 +149,21 @@ private:
 /// @param p_quantity the quantity of the LengthUnit
 /// @returns LengthUnit with the quantity
 template <Units Unit>
-auto makeLengthUnit(LengthUnit::QuantityType p_quantity) -> LengthUnit
+constexpr auto makeLengthUnit(LengthUnit::QuantityType p_quantity) -> LengthUnit
 {
     return LengthUnit{details::LengthUnitParams<LengthUnit::QuantityType, Unit>{p_quantity}};
 }
 
 
 /// arithmetic operations
-inline auto operator+(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs) -> jps::LengthUnit
+constexpr inline auto operator+(jps::LengthUnit p_lhs, jps::LengthUnit const & p_rhs)
+    -> jps::LengthUnit
 {
     p_lhs += p_rhs;
     return p_lhs;
 }
 
-inline auto operator-(jps::LengthUnit const & p_lhs, jps::LengthUnit const & p_rhs)
+constexpr inline auto operator-(jps::LengthUnit const & p_lhs, jps::LengthUnit const & p_rhs)
     -> jps::LengthUnit
 {
     auto res{p_lhs};
@@ -170,24 +171,24 @@ inline auto operator-(jps::LengthUnit const & p_lhs, jps::LengthUnit const & p_r
     return res;
 }
 
-inline auto operator*(double p_scalar, jps::LengthUnit p_lu) -> jps::LengthUnit
+constexpr inline auto operator*(double p_scalar, jps::LengthUnit p_lu) -> jps::LengthUnit
 {
     return p_lu * p_scalar;
 }
 
-inline auto operator-(jps::LengthUnit p_lu) -> jps::LengthUnit
+constexpr inline auto operator-(jps::LengthUnit p_lu) -> jps::LengthUnit
 {
     p_lu.m_quantity = -p_lu.m_quantity;
     return p_lu;
 }
 
-inline auto operator*(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit
+constexpr inline auto operator*(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit
 {
     p_lu.m_quantity *= p_scalar;
     return p_lu;
 }
 
-inline auto operator/(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit
+constexpr inline auto operator/(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit
 {
     p_lu.m_quantity /= p_scalar;
     return p_lu;
@@ -195,32 +196,32 @@ inline auto operator/(jps::LengthUnit p_lu, double p_scalar) -> jps::LengthUnit
 } // namespace jps
 /// User defined literals for all units
 /// Note that the cast is needed to silence compiler warning about narrowing down precision
-inline auto operator"" _um(long double p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _um(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::um>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _mm(long double p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _mm(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::mm>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _cm(long double p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _cm(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::cm>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _dm(long double p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _dm(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::dm>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _m(long double p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _m(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::m>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _km(long double p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _km(long double p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::km>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
@@ -228,32 +229,32 @@ inline auto operator"" _km(long double p_quantity) -> jps::LengthUnit
 
 /// User defined literals for integrals
 /// Note that the cast is needed to silence compiler warning about narrowing down precision
-inline auto operator"" _um(unsigned long long p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _um(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::um>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _mm(unsigned long long p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _mm(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::mm>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _cm(unsigned long long p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _cm(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::cm>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _dm(unsigned long long p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _dm(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::dm>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _m(unsigned long long p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _m(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::m>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));
 }
-inline auto operator"" _km(unsigned long long p_quantity) -> jps::LengthUnit
+constexpr inline auto operator"" _km(unsigned long long p_quantity) -> jps::LengthUnit
 {
     return jps::makeLengthUnit<jps::Units::km>(
         static_cast<jps::LengthUnit::QuantityType>(p_quantity));


### PR DESCRIPTION
Add missing `constexpr` qualifier to `LengthUnit`, s.th. the data type can be used in `constexpr` context.
