### PR TITLE
Bounding box in level storage

### DIFF
--- a/cpp/libcore/source/geometry/level_storage.cpp
+++ b/cpp/libcore/source/geometry/level_storage.cpp
@@ -26,9 +26,9 @@ auto LevelStorage::computeBoundingBox() -> BoundingBox
 
     // extract all coordinates from different components of level storage
     // extract from line segments
-    for(const auto & line_segement : m_line_segments) {
-        all_coordinates.push_back(line_segement.getStart());
-        all_coordinates.push_back(line_segement.getEnd());
+    for(const auto & line_segment : m_line_segments) {
+        all_coordinates.push_back(line_segment.getStart());
+        all_coordinates.push_back(line_segment.getEnd());
     }
 
     // extract from special areas

--- a/cpp/libcore/source/geometry/level_storage.hpp
+++ b/cpp/libcore/source/geometry/level_storage.hpp
@@ -10,6 +10,16 @@
 
 namespace jps
 {
+/// Struct to hold the information of lower left and upper right corner which define the bounding
+/// box.
+struct BoundingBox {
+    Coordinate lower_left;  // NOLINTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+    Coordinate upper_right; // NOLINTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+
+    BoundingBox(Coordinate p_lower_left, Coordinate p_upper_right) :
+        lower_left(p_lower_left), upper_right(p_upper_right){};
+};
+
 class LevelStorage
 {
     std::vector<LineSegment> m_line_segments;
@@ -22,5 +32,8 @@ public:
     auto getAgents() -> std::vector<Agent> & { return m_agents; };
     auto getAgents() const -> std::vector<Agent> const & { return m_agents; };
     auto addAgent(Coordinate const & p_coordinate) -> void;
+
+    /// Compute a bounding box based on the current entities in LevelStorage
+    auto computeBoundingBox() -> BoundingBox;
 };
 } // namespace jps

--- a/cpp/libcore/source/geometry/level_storage.hpp
+++ b/cpp/libcore/source/geometry/level_storage.hpp
@@ -13,8 +13,10 @@ namespace jps
 /// Struct to hold the information of lower left and upper right corner which define the bounding
 /// box.
 struct BoundingBox {
-    Coordinate lower_left;  // NOLINTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-    Coordinate upper_right; // NOLINTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+    [[maybe_unused]] Coordinate
+        lower_left; // NOLINTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+    [[maybe_unused]] Coordinate
+        upper_right; // NOLINTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
 
     BoundingBox(Coordinate p_lower_left, Coordinate p_upper_right) :
         lower_left(p_lower_left), upper_right(p_upper_right){};


### PR DESCRIPTION
This PR provides a method to compute the bounding box based on the current entities in the level storage (line segments, special areas and agents). The method should simplify implementations that require a grid in the world (e.g. floodfill).

The bounding box is not stored/maintained in the level storage and must be explicitly called if required. 

Please note: I am not sure about the most efficient way to use std function to find the min/max. Since different data structures have to be searched, I decided to collect all coordinates and then find the min/max at the end.